### PR TITLE
Drop authorship/divisions/outlines/terms quiz topics

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,11 @@
 {
   "firestore": {
     "rules": "firestore.rules"
+  },
+  "hosting": {
+    "site": "scripturemastery",
+    "public": "dist",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [{ "source": "**", "destination": "/index.html" }]
   }
 }

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -212,9 +212,18 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
           <div className="row" style={{ marginTop: 14 }}>
             {wasCorrect ? (
               <>
-                <button className="btn sm" onClick={() => onGrade(1)}>Hard <span className="kbd">1</span></button>
-                <button className="btn primary sm" onClick={() => onGrade(2)}>Good <span className="kbd">2</span></button>
-                <button className="btn sm" onClick={() => onGrade(3)}>Easy <span className="kbd">3</span></button>
+                <button className="btn sm" onClick={() => onGrade(1)}>
+                  Hard <span className="kbd">1</span>
+                  <span className="hint">see it more often</span>
+                </button>
+                <button className="btn primary sm" onClick={() => onGrade(2)}>
+                  Good <span className="kbd">2</span>
+                  <span className="hint">normal pace</span>
+                </button>
+                <button className="btn sm" onClick={() => onGrade(3)}>
+                  Easy <span className="kbd">3</span>
+                  <span className="hint">see it less often</span>
+                </button>
               </>
             ) : (
               <>

--- a/src/data/extras.ts
+++ b/src/data/extras.ts
@@ -62,16 +62,6 @@ export const LISTS: OrderedList[] = [
     items: ['Water into wine at Cana', 'Healing the official’s son', 'Healing the paralytic at Bethesda', 'Feeding the five thousand', 'Walking on water', 'Healing the man born blind', 'Raising Lazarus'],
   },
   {
-    id: 'divisions-ot', title: 'The Five Divisions of the Old Testament', note: 'In canonical order',
-    ordered: true,
-    items: ['Law (5 books)', 'History (12 books)', 'Wisdom/Poetry (5 books)', 'Major Prophets (5 books)', 'Minor Prophets (12 books)'],
-  },
-  {
-    id: 'divisions-nt', title: 'The Five Divisions of the New Testament', note: 'In canonical order',
-    ordered: true,
-    items: ['Gospels (4 books)', 'History — Acts (1 book)', 'Pauline Epistles (13 books)', 'General Epistles (8 books)', 'Prophecy — Revelation (1 book)'],
-  },
-  {
     id: 'journeys', title: 'Paul’s Journeys in Acts', note: 'In order',
     ordered: true,
     items: ['First missionary journey (Acts 13–14)', 'Jerusalem Council (Acts 15)', 'Second missionary journey (Acts 15–18)', 'Third missionary journey (Acts 18–21)', 'Arrest in Jerusalem (Acts 21–23)', 'Voyage to Rome (Acts 27–28)'],
@@ -96,23 +86,10 @@ export const AUTHORED: Item[] = [
   { id: 'a-paul-letters', kind: 'type', topic: 'numbers', tier: 1, prompt: 'How many New Testament letters are attributed to Paul?', answer: '13', accepts: ['thirteen'], explain: 'Romans through Philemon. Hebrews is anonymous and counted separately.' },
   { id: 'a-gospels-count', kind: 'type', topic: 'numbers', tier: 1, prompt: 'How many Gospels are there, and what are they?', answer: 'Four: Matthew, Mark, Luke, John', accepts: ['4', 'four', 'matthew mark luke john'] },
 
-  // ---- Divisions and structure
-  { id: 'a-pentateuch', kind: 'type', topic: 'divisions', tier: 1, prompt: 'What is the name for the first five books of the Bible?', answer: 'The Pentateuch', accepts: ['pentateuch', 'the law', 'torah'], explain: 'Also called the Torah or the Law — Genesis through Deuteronomy.' },
-  { id: 'a-synoptics', kind: 'type', topic: 'divisions', tier: 1, prompt: 'Which three Gospels are called the Synoptic Gospels?', answer: 'Matthew, Mark, and Luke', accepts: ['matthew mark luke', 'matthew, mark, luke'], explain: '"Synoptic" means "seen together" — they share much of the same material. John stands apart.' },
-  { id: 'a-major-minor', kind: 'mcq', topic: 'divisions', tier: 1, prompt: 'What distinguishes the Major Prophets from the Minor Prophets?', answer: 'The length of the books, not their importance', distractors: ['How accurate their prophecies were', 'Whether they prophesied before or after the exile', 'Whether they wrote to Israel or Judah'], explain: 'Major = longer (Isaiah, Jeremiah, Lamentations, Ezekiel, Daniel). Minor = shorter, the twelve.' },
-  { id: 'a-prison-epistles', kind: 'mcq', topic: 'divisions', tier: 2, prompt: 'Which four letters are known as the Prison Epistles?', answer: 'Ephesians, Philippians, Colossians, Philemon', distractors: ['Romans, Galatians, Ephesians, Philippians', '1 & 2 Timothy, Titus, Philemon', 'Colossians, 1 & 2 Thessalonians, Philemon'], explain: 'All four were written while Paul was imprisoned, most likely in Rome.' },
-  { id: 'a-pastoral-epistles', kind: 'mcq', topic: 'divisions', tier: 2, prompt: 'Which letters are the Pastoral Epistles?', answer: '1 Timothy, 2 Timothy, and Titus', distractors: ['Ephesians, Philippians, and Colossians', 'James, 1 Peter, and 2 Peter', '1, 2, and 3 John'], explain: 'They were written to individual pastors rather than to congregations.' },
-  { id: 'a-psalms-books', kind: 'mcq', topic: 'divisions', tier: 3, prompt: 'The book of Psalms is divided into how many "books"?', answer: 'Five', distractors: ['Three', 'Seven', 'Twelve'], explain: 'Psalms 1–41, 42–72, 73–89, 90–106, 107–150 — each closing with a doxology.' },
-  { id: 'a-last-ot', kind: 'type', topic: 'divisions', tier: 1, prompt: 'What is the last book of the Old Testament?', answer: 'Malachi', accepts: ['malachi'] },
-  { id: 'a-first-nt', kind: 'type', topic: 'divisions', tier: 1, prompt: 'What is the first book of the New Testament?', answer: 'Matthew', accepts: ['matthew'] },
+  // ---- Structure
   { id: 'a-silence', kind: 'mcq', topic: 'timeline', tier: 2, prompt: 'About how many years passed between Malachi and the New Testament?', answer: 'About 400 years', distractors: ['About 100 years', 'About 700 years', 'About 40 years'], explain: 'Called the intertestamental period or the "400 silent years."' },
 
   // ---- Cross-book connections
-  { id: 'a-luke-acts', kind: 'mcq', topic: 'authorship', tier: 1, prompt: 'Which two New Testament books were written by the same author as a two-volume work?', answer: 'Luke and Acts', distractors: ['Matthew and Mark', 'John and Revelation', 'Hebrews and James'], explain: 'Both are addressed to Theophilus; Acts picks up where Luke ends.' },
-  { id: 'a-gentile-author', kind: 'type', topic: 'authorship', tier: 2, prompt: 'Who is generally considered the only Gentile author in the Bible?', answer: 'Luke', accepts: ['luke'], explain: 'A physician and Paul’s travel companion; he wrote Luke and Acts.' },
-  { id: 'a-hebrews-author', kind: 'mcq', topic: 'authorship', tier: 2, prompt: 'Who wrote the book of Hebrews?', answer: 'The author is unknown', distractors: ['Paul', 'Apollos', 'Barnabas'], explain: 'Hebrews is anonymous. Paul, Apollos, Barnabas, and Priscilla have all been proposed.' },
-  { id: 'a-johns-books', kind: 'mcq', topic: 'authorship', tier: 2, prompt: 'How many New Testament books are traditionally attributed to the apostle John?', answer: 'Five', distractors: ['Three', 'Two', 'Four'], explain: 'The Gospel of John, 1–3 John, and Revelation.' },
-  { id: 'a-moses-books', kind: 'type', topic: 'authorship', tier: 1, prompt: 'How many books of the Bible are traditionally attributed to Moses?', answer: 'Five', accepts: ['5', 'five'], explain: 'Genesis through Deuteronomy — the Pentateuch.' },
   { id: 'a-no-god-named', kind: 'type', topic: 'summaries', tier: 2, prompt: 'Which book of the Bible never mentions God by name?', answer: 'Esther', accepts: ['esther'], explain: 'God is never named, yet His providence drives the entire plot.' },
   { id: 'a-joel-pentecost', kind: 'mcq', topic: 'events', tier: 3, prompt: 'At Pentecost, Peter quoted which Old Testament prophet?', answer: 'Joel', distractors: ['Isaiah', 'Amos', 'Zechariah'], explain: 'Joel 2:28 — "I will pour out my Spirit on all flesh."' },
   { id: 'a-micah-bethlehem', kind: 'mcq', topic: 'events', tier: 3, prompt: 'Which prophet foretold that the Messiah would be born in Bethlehem?', answer: 'Micah', distractors: ['Isaiah', 'Malachi', 'Hosea'], explain: 'Micah 5:2, quoted to Herod by the chief priests in Matthew 2.' },
@@ -163,7 +140,5 @@ export const LIST_DECOYS: Record<string, string[]> = {
   beatitudes: ['the wealthy', 'the wise', 'the strong', 'the learned'],
   'i-am': ['I am the cornerstone', 'I am the rock of ages', 'I am the living water', 'I am the lamb of God'],
   signs: ['Calming the storm', 'Healing the ten lepers', 'Cursing the fig tree', 'Feeding the four thousand'],
-  'divisions-ot': ['Gospels (4 books)', 'Epistles (21 books)', 'Apocalyptic (1 book)', 'Proverbs (1 book)'],
-  'divisions-nt': ['Law (5 books)', 'Minor Prophets (12 books)', 'Wisdom (5 books)', 'History (12 books)'],
   journeys: ['Fourth missionary journey', 'Mission to Spain', 'Council of Antioch', 'Voyage to Alexandria'],
 };

--- a/src/data/plan.ts
+++ b/src/data/plan.ts
@@ -3,8 +3,8 @@ import { BOOKS } from './books';
 
 /**
  * A phased plan built backwards from the exam date. The ordering is deliberate:
- * the frame (order, divisions, authors, summaries) comes first, because every
- * later fact has to hang on something. Detail without a frame does not stick.
+ * the frame (order, summaries) comes first, because every later fact has to
+ * hang on something. Detail without a frame does not stick.
  */
 export interface Phase {
   id: string;
@@ -22,26 +22,23 @@ export const PHASES: Phase[] = [
   {
     id: 'frame',
     name: 'Phase 1 — Build the Frame',
-    goal: 'Know all 66 books cold: order, division, author, and one-sentence summary. Nothing else sticks without this.',
+    goal: 'Know all 66 books cold: order and one-sentence summary. Nothing else sticks without this.',
     weight: 3,
-    topics: ['book-order', 'divisions', 'authorship', 'summaries', 'outlines'],
+    topics: ['book-order', 'summaries'],
     scope: 'all',
     drills: [
       'Recite the 66 books in order out loud, daily',
-      'Sort every book into its division without looking',
       'Match each book to its one-line summary',
-      'Name the author of any book called out at random',
     ],
   },
   {
     id: 'ot-sweep',
     name: 'Phase 2 — Old Testament Sweep',
-    goal: 'Walk the OT storyline book by book: outline, key chapters, people, events, and the terms each book runs on.',
+    goal: 'Walk the OT storyline book by book: key chapters, people, and events.',
     weight: 3,
-    topics: ['chapters', 'outlines', 'people', 'relationships', 'events', 'places', 'terms'],
+    topics: ['chapters', 'people', 'relationships', 'events', 'places'],
     scope: BOOKS.filter((b) => b.testament === 'OT').map((b) => b.id),
     drills: [
-      'For each book, recite its outline — the movements, in order, by chapter',
       'For each book, say its key chapters and what happens in them',
       'Tell the OT story start to finish in five minutes, no notes',
       'Identify every major character from a one-line clue',
@@ -51,15 +48,15 @@ export const PHASES: Phase[] = [
   {
     id: 'nt-sweep',
     name: 'Phase 3 — New Testament Sweep',
-    goal: 'Walk the NT: Gospels, Acts, the letters — audience, occasion, and outline — and Revelation.',
+    goal: 'Walk the NT: Gospels, Acts, the letters — audience and occasion — and Revelation.',
     weight: 2.5,
-    topics: ['chapters', 'outlines', 'people', 'relationships', 'events', 'places', 'terms'],
+    topics: ['chapters', 'people', 'relationships', 'events', 'places'],
     scope: BOOKS.filter((b) => b.testament === 'NT').map((b) => b.id),
     drills: [
       'Name all 13 Pauline letters in order and their one-line point',
       'Trace Paul’s journeys through Acts, city by city',
-      'Distinguish the four Gospels by audience, emphasis, and structure',
-      'For each letter: who wrote it, to whom, from where, and why',
+      'Distinguish the four Gospels by audience and emphasis',
+      'For each letter: to whom, from where, and why',
     ],
   },
   {
@@ -67,7 +64,7 @@ export const PHASES: Phase[] = [
     name: 'Phase 4 — Timeline & Connections',
     goal: 'Lock the chronology and the standing lists, then connect books to eras.',
     weight: 2,
-    topics: ['timeline', 'numbers', 'summaries', 'christ', 'terms'],
+    topics: ['timeline', 'numbers', 'summaries', 'christ'],
     scope: 'all',
     drills: [
       'Put the 14 eras in order from memory',
@@ -82,7 +79,7 @@ export const PHASES: Phase[] = [
     name: 'Phase 5 — Mixed Review & Mock Quizzes',
     goal: 'No new material. Mixed review, weak spots, and full-length practice under time.',
     weight: 2,
-    topics: ['book-order', 'divisions', 'authorship', 'summaries', 'outlines', 'chapters', 'people', 'relationships', 'events', 'places', 'timeline', 'numbers', 'terms', 'christ'],
+    topics: ['book-order', 'summaries', 'chapters', 'people', 'relationships', 'events', 'places', 'timeline', 'numbers', 'christ'],
     scope: 'all',
     drills: [
       'Take a 40-question mixed quiz every other day',

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -77,10 +77,7 @@ export interface Item {
 
 export type Topic =
   | 'book-order'
-  | 'authorship'
-  | 'divisions'
   | 'summaries'
-  | 'outlines'
   | 'chapters'
   | 'people'
   | 'relationships'
@@ -88,15 +85,11 @@ export type Topic =
   | 'places'
   | 'timeline'
   | 'numbers'
-  | 'terms'
   | 'christ';
 
 export const TOPIC_LABELS: Record<Topic, string> = {
   'book-order': 'Book Order',
-  authorship: 'Authorship',
-  divisions: 'Divisions & Genre',
   summaries: 'Book Summaries',
-  outlines: 'Book Outlines',
   chapters: 'Chapter Content',
   people: 'People',
   relationships: 'Family & Relationships',
@@ -104,6 +97,5 @@ export const TOPIC_LABELS: Record<Topic, string> = {
   places: 'Places',
   timeline: 'Timeline',
   numbers: 'Numbers & Counts',
-  terms: 'Terms & Concepts',
   christ: 'Christ in Scripture',
 };

--- a/src/lib/generate-detail.ts
+++ b/src/lib/generate-detail.ts
@@ -8,11 +8,8 @@ const bookAbbr = new Map(BOOKS.map((b) => [b.id, b.abbr]));
 
 /** Every "what" across every book — the pool for chapter-content distractors. */
 const allEventWhats = DETAILS.flatMap((d) => d.events.map((e) => e.what));
-const allSectionTitles = DETAILS.flatMap((d) => d.outline.map((s) => s.title));
 const allFigureDeeds = DETAILS.flatMap((d) => d.figures.map((f) => f.did));
 const allFigureNames = [...new Set(DETAILS.flatMap((d) => d.figures.map((f) => f.name)))];
-const allTermNames = [...new Set(DETAILS.flatMap((d) => d.terms?.map((t) => t.term) ?? []))];
-const allTermMeanings = DETAILS.flatMap((d) => d.terms?.map((t) => t.meaning) ?? []);
 const allNumberValues = DETAILS.flatMap((d) => d.numbers?.map((n) => n.value) ?? []);
 const allChristLines = DETAILS.map((d) => d.christ);
 const allPurposes = DETAILS.map((d) => d.purpose);
@@ -59,49 +56,6 @@ function booksWithEventName(name: string): Set<string> {
     if (d.events.some((e) => e.name.toLowerCase() === key)) out.add(bookName.get(d.book)!);
   }
   return out;
-}
-
-function outlineItems(d: BookDetail): Item[] {
-  const items: Item[] = [];
-  const name = bookName.get(d.book)!;
-  const ownTitles = d.outline.map((s) => s.title);
-
-  d.outline.forEach((sec, i) => {
-    // Chapters → section. Distractors prefer this book's other sections, which
-    // makes the question about structure rather than about vocabulary.
-    const pool = ownTitles.length >= 4 ? ownTitles : allSectionTitles;
-    items.push({
-      id: `det-outline-${d.book}-${i}`, kind: 'mcq', topic: 'outlines', tier: 2, book: d.book,
-      prompt: `In ${name}, what do chapters ${sec.ch} cover?`,
-      answer: sec.title,
-      distractors: pickDistractors(pool, sec.title, 3, `out-${d.book}-${i}`),
-      explain: `${name} outline: ${d.outline.map((s) => `${s.ch} — ${s.title}`).join(' · ')}`,
-    });
-
-    // Section → chapters, within this book only.
-    if (d.outline.length >= 4) {
-      items.push({
-        id: `det-outline-ch-${d.book}-${i}`, kind: 'mcq', topic: 'outlines', tier: 3, book: d.book,
-        prompt: `Which chapters of ${name} cover this? "${sec.title}"`,
-        answer: sec.ch,
-        distractors: pickDistractors(d.outline.map((s) => s.ch), sec.ch, 3, `outc-${d.book}-${i}`),
-      });
-    }
-  });
-
-  // Recite the skeleton in order.
-  if (d.outline.length >= 3) {
-    const window = d.outline.slice(0, Math.min(5, d.outline.length));
-    items.push({
-      id: `det-outline-order-${d.book}`, kind: 'order', topic: 'outlines', tier: 2, book: d.book,
-      prompt: `Put the movements of ${name} in order.`,
-      answer: window.map((s) => s.title).join(' → '),
-      sequence: window.map((s) => s.title),
-      explain: window.map((s) => `${s.ch}: ${s.title}`).join(' · '),
-    });
-  }
-
-  return items;
 }
 
 function eventItems(d: BookDetail): Item[] {
@@ -277,31 +231,6 @@ function figureItems(d: BookDetail): Item[] {
   return items;
 }
 
-function termItems(d: BookDetail): Item[] {
-  const items: Item[] = [];
-  const name = bookName.get(d.book)!;
-
-  for (const t of d.terms ?? []) {
-    const key = `${d.book}-${slug(t.term)}`;
-    items.push({
-      id: `det-term-mean-${key}`, kind: 'mcq', topic: 'terms', tier: 2, book: d.book,
-      prompt: `What does "${t.term}" mean?`,
-      answer: t.meaning,
-      distractors: pickDistractors(allTermMeanings, t.meaning, 3, `tm-${key}`),
-      explain: `A key term in ${name}.`,
-    });
-    items.push({
-      id: `det-term-name-${key}`, kind: 'mcq', topic: 'terms', tier: 3, book: d.book,
-      prompt: `Which term is this? "${t.meaning}"`,
-      answer: t.term,
-      distractors: pickDistractors(allTermNames, t.term, 3, `tn-${key}`),
-      explain: `From ${name}.`,
-    });
-  }
-
-  return items;
-}
-
 function numberItems(d: BookDetail): Item[] {
   const items: Item[] = [];
   const name = bookName.get(d.book)!;
@@ -422,19 +351,6 @@ function crossBookItems(): Item[] {
     });
   }
 
-  // Which book is this outline from? Tests the skeleton, not the details.
-  for (const d of DETAILS) {
-    if (d.outline.length < 4) continue;
-    const shape = d.outline.map((s) => s.title.split(' — ')[0]).slice(0, 4).join(' · ');
-    items.push({
-      id: `det-x-outline-book-${d.book}`, kind: 'mcq', topic: 'outlines', tier: 3, book: d.book,
-      prompt: `Which book has this shape? "${shape}"`,
-      answer: bookName.get(d.book)!,
-      distractors: pickDistractors(BOOKS.map((b) => b.name), bookName.get(d.book)!, 3, `xo-${d.book}`),
-      explain: d.purpose,
-    });
-  }
-
   return items;
 }
 
@@ -442,10 +358,8 @@ export function buildDetailItems(): Item[] {
   const items: Item[] = [];
   for (const d of DETAILS) {
     items.push(
-      ...outlineItems(d),
       ...eventItems(d),
       ...figureItems(d),
-      ...termItems(d),
       ...numberItems(d),
       ...frameItems(d),
     );

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -7,8 +7,6 @@ import { buildDetailItems } from './generate-detail';
 import { pickDistractors, seededShuffle } from './rng';
 
 const bookNames = BOOKS.map((b) => b.name);
-const authors = [...new Set(BOOKS.map((b) => b.author))];
-const divisions = [...new Set(BOOKS.map((b) => b.division))];
 const chapterCounts = [...new Set(BOOKS.map((b) => String(b.chapters)))];
 
 /** Distractors drawn from the same division are hard but fair. */
@@ -22,24 +20,6 @@ function buildBookItems(): Item[] {
   const items: Item[] = [];
 
   for (const b of BOOKS) {
-    // --- Authorship
-    items.push({
-      id: `gen-author-${b.id}`, kind: 'mcq', topic: 'authorship', tier: 1, book: b.id,
-      prompt: `Who is the traditional author of ${b.name}?`,
-      answer: b.author,
-      distractors: pickDistractors(authors, b.author, 3, `author-${b.id}`),
-      explain: b.authorNote,
-    });
-
-    // --- Division
-    items.push({
-      id: `gen-division-${b.id}`, kind: 'mcq', topic: 'divisions', tier: 1, book: b.id,
-      prompt: `Which division of the Bible does ${b.name} belong to?`,
-      answer: b.division,
-      distractors: pickDistractors(divisions, b.division, 3, `div-${b.id}`),
-      explain: `${b.name} is book ${b.order} of 66, in the ${b.testament === 'OT' ? 'Old' : 'New'} Testament.`,
-    });
-
     // --- Chapter count. Distractors are drawn from numerically nearby counts;
     // offering 50 against 3, 5, and 7 tests nothing.
     items.push({

--- a/src/styles.css
+++ b/src/styles.css
@@ -111,6 +111,7 @@ button.btn.primary { background: var(--accent); border-color: var(--accent); col
 button.btn.primary:hover:not(:disabled) { filter: brightness(1.08); }
 button.btn:disabled { opacity: 0.45; cursor: not-allowed; }
 button.btn.sm { padding: 5px 11px; font-size: 0.8rem; }
+button.btn .hint { display: block; font-size: 0.66rem; font-weight: 400; opacity: 0.7; margin-top: 2px; }
 
 .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
 .spread { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; }


### PR DESCRIPTION
## Summary
- Removes the authorship, divisions, and outline/term quiz topics and their backing data across `extras.ts`, `plan.ts`, `types.ts`, `generate.ts`, and `generate-detail.ts` — these tested memorization of structure that didn't hold up well under quizzing and diluted the higher-value topics.
- Adds a short hint (`see it more/less often`, `normal pace`) under each Hard/Good/Easy grading button in `QuestionCard.tsx` so the spacing effect of each choice is clear at a glance.
- Adds a `hosting` block to `firebase.json` targeting the `scripturemastery` Firebase Hosting site, so `dist/` can be deployed there.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run validate` — all content-integrity checks pass
- [ ] Manual smoke test of grading button hints in the browser