### PR TITLE
Add a Playwright suite covering the app behind the sign-in gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# A newer push to the same PR supersedes an in-flight run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Typecheck, content, browser tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Typecheck
+        run: npm run check
+
+      - name: Content integrity
+        run: npm run validate
+
+      # Both Playwright projects are Chromium-based, so that is all we install.
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      # No Firebase secrets here on purpose: the E2E build swaps the Firestore
+      # transport for a localStorage stand-in (see vite.config.ts), so the suite
+      # needs no credentials and cannot touch real user data.
+      - name: Browser tests
+        run: npm run test:e2e
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,12 @@ dist
 /.playwright-mcp/
 /shots/
 /*.png
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/.playwright/
+
+# Firebase deploy cache
+/.firebase/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npm install
 npm run dev      # http://localhost:5173
 npm run build    # static output in dist/ — deployable anywhere
 npm run validate # content-integrity checks over the whole item bank
+npm run test:e2e # Playwright: 82 browser tests over the real UI
 ```
 
 Progress syncs to **Firestore**, keyed to a Google sign-in restricted to
@@ -241,6 +242,47 @@ answer. Flagging shared prompts would have flagged those. The check that actuall
 means something is narrower — **one card's correct answer appearing as a wrong
 option on another card asking the same question** — plus identical prompt *and*
 identical option set with different answers. Both currently report zero.
+
+### Browser tests
+
+`npm run test:e2e` drives the actual app in Chromium — 82 tests over sign-in and
+the domain gate, tab routing, all three question kinds, review sessions, quiz
+filters, the reference search, and export/import/reset. A second project runs
+the mobile refusal on an emulated Pixel 5, because the one thing that must never
+happen on a phone is the app letting you in.
+
+**Getting past Google sign-in.** Every screen but the splash sits behind a
+Firebase popup, and the emulators need a JVM. So the E2E build swaps two modules
+and nothing else: `src/lib/useStore.ts` and `src/lib/firebase.ts` are replaced by
+`*.e2e.ts` stand-ins that keep the store in localStorage and make sign-in a
+synchronous write. The swap lives in a vite plugin gated on `E2E=1`
+(`vite.config.ts`), so a production build has never heard of it — `npm run build`
+output contains zero E2E code and still ships the real Firebase SDK.
+
+The point of that split is that the stand-in replaces the *transport only*.
+Everything that decides what the store becomes when you answer a card lives in
+`src/lib/store-ops.ts`, which both hooks call, so a browser test exercises the
+real grading, logging and exam-clamp logic rather than a re-implementation of
+it. The stand-in declares `StoreApi` as its return type: if the real hook's
+surface changes, the fake stops compiling.
+
+Tests seed a whole `Store` into localStorage before the app boots and read it
+back afterwards (`tests/e2e/harness.ts`). Where a test needs a known question on
+screen, it seeds one due card with `newLimit: 0` so the queue can only contain
+that one — no shuffling, no flake. The three fixture item ids are pinned by
+`content-contract.spec.ts`, so if the generator ever retires one, that says so
+directly instead of a dozen UI tests failing for no visible reason.
+
+**One known bug is recorded as a failing test.** `review.spec.ts` carries a
+`test.fail()` for the requeue bug described below; delete the marker when it is
+fixed and Playwright will flag the test as unexpectedly passing.
+
+> Miss the last card of a session and it is requeued — but it comes back already
+> answered, with the wrong answer still in a disabled input. The session card is
+> keyed on `item.id` (`src/views/Review.tsx:127`), so when the same id repeats
+> back to back React reuses the component and `QuestionCard`'s reset effect,
+> keyed on that same id, never fires. You are never actually re-asked, which is
+> the whole point of requeueing. Keying on the queue position fixes it.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1426,6 +1427,22 @@
         "node": "^22.20 || ^24.12 || >=25"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2426,6 +2443,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.26",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,13 @@
   "description": "A spaced-repetition study system for whole-Bible survey knowledge.",
   "scripts": {
     "dev": "vite",
+    "dev:e2e": "E2E=1 vite --port 5174 --strictPort",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "check": "tsc -b --noEmit false --pretty",
-    "validate": "vite-node scripts/validate.ts"
+    "check": "tsc -b --pretty",
+    "validate": "vite-node scripts/validate.ts",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "firebase": "^12.17.1",
@@ -17,6 +20,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 5174;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : [['list']],
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'desktop',
+      use: { ...devices['Desktop Chrome'] },
+      // The refusal screen is the one thing that must NOT render on a desktop.
+      testIgnore: '**/mobile-gate.spec.ts',
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['Pixel 5'] },
+      testMatch: '**/mobile-gate.spec.ts',
+    },
+  ],
+
+  // Starts the app with the localStorage stand-ins wired in (see vite.config.ts).
+  webServer: {
+    command: 'npm run dev:e2e',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
+});

--- a/src/lib/e2e-keys.ts
+++ b/src/lib/e2e-keys.ts
@@ -1,0 +1,20 @@
+/**
+ * The contract between the E2E stand-ins and the Playwright harness.
+ *
+ * Both localStorage keys are written by tests before the app boots
+ * (`tests/e2e/harness.ts`), and read back by `useStore.e2e.ts`. Only ever
+ * loaded in the E2E build.
+ */
+
+/** Holds the signed-in email, or is absent when signed out. */
+export const E2E_AUTH_KEY = 'e2e:auth';
+
+/** Holds the whole Store as JSON — how a test seeds cards, log and settings. */
+export const E2E_STORE_KEY = 'e2e:store';
+
+/** Same-tab auth change; `storage` only fires for *other* tabs. */
+export const E2E_AUTH_EVENT = 'e2e:auth-changed';
+
+export function e2eNotifyAuth(): void {
+  window.dispatchEvent(new Event(E2E_AUTH_EVENT));
+}

--- a/src/lib/firebase.e2e.ts
+++ b/src/lib/firebase.e2e.ts
@@ -1,0 +1,39 @@
+/**
+ * The E2E stand-in for ./firebase.
+ *
+ * Aliased over the real module only when vite runs with E2E=1 (see
+ * vite.config.ts) — it is never part of a production bundle. Keeping Firebase
+ * out of the E2E graph entirely means no SDK init, no IndexedDB cache, and no
+ * network: sign-in is a localStorage write and a synchronous event.
+ */
+import { E2E_AUTH_KEY, e2eNotifyAuth } from './e2e-keys';
+
+/** Kept in sync by hand with the copy enforced in firestore.rules. */
+export const ALLOWED_DOMAINS = ['acts2.network', 'gpmail.org'];
+
+export function isAllowedEmail(email: string | null | undefined): boolean {
+  const domain = email?.split('@')[1]?.toLowerCase();
+  return !!domain && ALLOWED_DOMAINS.includes(domain);
+}
+
+/**
+ * Stands in for the Google popup. A test decides the outcome up front by
+ * seeding `e2e:next-sign-in` — an email to accept, or the literal `cancel` to
+ * make the button reject the way a dismissed popup does.
+ */
+export async function signIn(): Promise<void> {
+  const next = localStorage.getItem('e2e:next-sign-in') ?? 'member@acts2.network';
+  if (next === 'cancel') {
+    throw new Error('The sign-in popup was closed before completing.');
+  }
+  if (!isAllowedEmail(next)) {
+    throw new Error(`Sign-in is restricted to ${ALLOWED_DOMAINS.join(' and ')} accounts.`);
+  }
+  localStorage.setItem(E2E_AUTH_KEY, next);
+  e2eNotifyAuth();
+}
+
+export async function signOutUser(): Promise<void> {
+  localStorage.removeItem(E2E_AUTH_KEY);
+  e2eNotifyAuth();
+}

--- a/src/lib/store-ops.ts
+++ b/src/lib/store-ops.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure store transitions, split out of useStore.
+ *
+ * The hook owns the transport — Firestore in the app, localStorage in the E2E
+ * build — and nothing else. Everything that decides what a store *becomes* when
+ * you answer a card, star an item, or change a setting lives here, so both
+ * hooks run the same code and a browser test exercises the real logic rather
+ * than a re-implementation of it.
+ */
+import { todayISO, type Settings, type Store } from './storage';
+import { grade as gradeCard, newCard, type Grade } from './srs';
+
+const DAY_MS = 86_400_000;
+
+/** End of the exam day — the ceiling every SRS interval is clamped under. */
+export function examTimeOf(settings: Settings): number {
+  return new Date(`${settings.examDate}T23:59:59`).getTime();
+}
+
+export function daysLeftUntil(examTime: number, now = Date.now()): number {
+  return Math.max(0, Math.ceil((examTime - now) / DAY_MS));
+}
+
+/** Grade one card and fold the result into today's session log. */
+export function applyAnswer(
+  store: Store,
+  id: string,
+  g: Grade,
+  examTime: number,
+  now = Date.now(),
+): Store {
+  const card = store.cards[id] ?? newCard(id);
+  const next = gradeCard(card, g, examTime, now);
+  const date = todayISO(new Date(now));
+  const correct = g > 0 ? 1 : 0;
+  const seenToday = store.log.some((l) => l.date === date);
+  const log = seenToday
+    ? store.log.map((l) =>
+        l.date === date ? { ...l, reviewed: l.reviewed + 1, correct: l.correct + correct } : l,
+      )
+    : [...store.log, { date, reviewed: 1, correct }];
+  return { ...store, cards: { ...store.cards, [id]: next }, log };
+}
+
+export function applyToggleStar(store: Store, id: string): Store {
+  return {
+    ...store,
+    starred: store.starred.includes(id)
+      ? store.starred.filter((s) => s !== id)
+      : [...store.starred, id],
+  };
+}
+
+export function applyUpdateSettings(store: Store, patch: Partial<Settings>): Store {
+  return { ...store, settings: { ...store.settings, ...patch } };
+}
+
+/** Wipe review history but keep the member's settings. */
+export function applyReset(store: Store): Store {
+  return { ...store, cards: {}, log: [], starred: [] };
+}

--- a/src/lib/useStore.e2e.ts
+++ b/src/lib/useStore.e2e.ts
@@ -1,0 +1,122 @@
+/**
+ * The E2E stand-in for useStore.
+ *
+ * Aliased over the real hook only when vite runs with E2E=1 (see
+ * vite.config.ts) — never part of a production bundle. It swaps the transport
+ * (Firestore → localStorage) and nothing else: every transition still goes
+ * through ./store-ops, the same code the real hook runs, so a Playwright test
+ * exercises the actual grading, logging and clamping logic rather than a
+ * re-implementation of it.
+ *
+ * The declared `StoreApi` return type is deliberate — if the real hook's
+ * surface changes, this file stops compiling.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { User } from 'firebase/auth';
+import { isAllowedEmail } from './firebase.e2e';
+import { emptyStore, type Settings, type Store } from './storage';
+import type { CardState, Grade } from './srs';
+import { E2E_AUTH_EVENT, E2E_AUTH_KEY, E2E_STORE_KEY } from './e2e-keys';
+import {
+  applyAnswer,
+  applyReset,
+  applyToggleStar,
+  applyUpdateSettings,
+  daysLeftUntil,
+  examTimeOf,
+} from './store-ops';
+import type { AuthStatus, StoreApi } from './useStore';
+
+function readEmail(): string | null {
+  return localStorage.getItem(E2E_AUTH_KEY);
+}
+
+function readStore(): Store {
+  const raw = localStorage.getItem(E2E_STORE_KEY);
+  if (!raw) return emptyStore();
+  try {
+    const parsed = JSON.parse(raw) as Partial<Store>;
+    const base = emptyStore();
+    return {
+      cards: parsed.cards ?? base.cards,
+      settings: { ...base.settings, ...(parsed.settings ?? {}) },
+      log: parsed.log ?? base.log,
+      starred: parsed.starred ?? base.starred,
+    };
+  } catch {
+    return emptyStore();
+  }
+}
+
+function statusFor(email: string | null): AuthStatus {
+  if (!email) return 'signed-out';
+  return isAllowedEmail(email) ? 'ready' : 'denied';
+}
+
+/** A stand-in for the Firebase User — only `email` and `uid` are ever read. */
+function fakeUser(email: string): User {
+  return { uid: `e2e-${email}`, email, displayName: email.split('@')[0] } as User;
+}
+
+export function useStore(): StoreApi {
+  const [email, setEmail] = useState<string | null>(readEmail);
+  const [store, setStore] = useState<Store>(readStore);
+  const storeRef = useRef(store);
+  storeRef.current = store;
+
+  // Mirrors onAuthStateChanged: sign-in and sign-out re-render the shell.
+  useEffect(() => {
+    const sync = () => setEmail(readEmail());
+    window.addEventListener(E2E_AUTH_EVENT, sync);
+    window.addEventListener('storage', sync);
+    return () => {
+      window.removeEventListener(E2E_AUTH_EVENT, sync);
+      window.removeEventListener('storage', sync);
+    };
+  }, []);
+
+  const authStatus = statusFor(email);
+
+  const commit = useCallback((next: Store) => {
+    storeRef.current = next;
+    setStore(next);
+    localStorage.setItem(E2E_STORE_KEY, JSON.stringify(next));
+  }, []);
+
+  const examTime = useMemo(() => examTimeOf(store.settings), [store.settings]);
+
+  const answer = useCallback(
+    (id: string, g: Grade) => commit(applyAnswer(storeRef.current, id, g, examTime)),
+    [examTime, commit],
+  );
+
+  const toggleStar = useCallback(
+    (id: string) => commit(applyToggleStar(storeRef.current, id)),
+    [commit],
+  );
+
+  const updateSettings = useCallback(
+    (patch: Partial<Settings>) => commit(applyUpdateSettings(storeRef.current, patch)),
+    [commit],
+  );
+
+  const replaceStore = useCallback((next: Store) => commit(next), [commit]);
+
+  const reset = useCallback(() => commit(applyReset(storeRef.current)), [commit]);
+
+  return {
+    store,
+    cards: store.cards as Record<string, CardState>,
+    answer,
+    toggleStar,
+    updateSettings,
+    replaceStore,
+    reset,
+    examTime,
+    daysLeft: daysLeftUntil(examTime),
+    authStatus,
+    // The real hook waits on a Firestore snapshot; localStorage is already here.
+    storeReady: authStatus === 'ready',
+    user: email ? fakeUser(email) : null,
+  };
+}

--- a/src/lib/useStore.ts
+++ b/src/lib/useStore.ts
@@ -2,8 +2,16 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { onAuthStateChanged, type User } from 'firebase/auth';
 import { doc, onSnapshot, setDoc } from 'firebase/firestore';
 import { auth, db, isAllowedEmail } from './firebase';
-import { emptyStore, todayISO, type Settings, type Store } from './storage';
-import { grade as gradeCard, newCard, type CardState, type Grade } from './srs';
+import { emptyStore, type Settings, type Store } from './storage';
+import type { CardState, Grade } from './srs';
+import {
+  applyAnswer,
+  applyReset,
+  applyToggleStar,
+  applyUpdateSettings,
+  daysLeftUntil,
+  examTimeOf,
+} from './store-ops';
 
 export type AuthStatus = 'loading' | 'signed-out' | 'denied' | 'ready';
 
@@ -59,59 +67,28 @@ export function useStore() {
     [user, authStatus],
   );
 
-  const examTime = useMemo(
-    () => new Date(`${store.settings.examDate}T23:59:59`).getTime(),
-    [store.settings.examDate],
-  );
+  const examTime = useMemo(() => examTimeOf(store.settings), [store.settings]);
 
   const answer = useCallback(
-    (id: string, g: Grade) => {
-      const prev = storeRef.current;
-      const card = prev.cards[id] ?? newCard(id);
-      const next = gradeCard(card, g, examTime);
-      const date = todayISO();
-      const log = [...prev.log];
-      const todayEntry = log.find((l) => l.date === date);
-      if (todayEntry) {
-        todayEntry.reviewed += 1;
-        if (g > 0) todayEntry.correct += 1;
-      } else {
-        log.push({ date, reviewed: 1, correct: g > 0 ? 1 : 0 });
-      }
-      commit({ ...prev, cards: { ...prev.cards, [id]: next }, log });
-    },
+    (id: string, g: Grade) => commit(applyAnswer(storeRef.current, id, g, examTime)),
     [examTime, commit],
   );
 
   const toggleStar = useCallback(
-    (id: string) => {
-      const prev = storeRef.current;
-      commit({
-        ...prev,
-        starred: prev.starred.includes(id)
-          ? prev.starred.filter((s) => s !== id)
-          : [...prev.starred, id],
-      });
-    },
+    (id: string) => commit(applyToggleStar(storeRef.current, id)),
     [commit],
   );
 
   const updateSettings = useCallback(
-    (patch: Partial<Settings>) => {
-      const prev = storeRef.current;
-      commit({ ...prev, settings: { ...prev.settings, ...patch } });
-    },
+    (patch: Partial<Settings>) => commit(applyUpdateSettings(storeRef.current, patch)),
     [commit],
   );
 
   const replaceStore = useCallback((next: Store) => commit(next), [commit]);
 
-  const reset = useCallback(() => {
-    const prev = storeRef.current;
-    commit({ ...prev, cards: {}, log: [], starred: [] });
-  }, [commit]);
+  const reset = useCallback(() => commit(applyReset(storeRef.current)), [commit]);
 
-  const daysLeft = Math.max(0, Math.ceil((examTime - Date.now()) / 86_400_000));
+  const daysLeft = daysLeftUntil(examTime);
 
   return {
     store,

--- a/tests/e2e/content-contract.spec.ts
+++ b/tests/e2e/content-contract.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Guards the assumptions the rest of the suite seeds against.
+ *
+ * The item bank is generated, not authored, so a change to a generator rule can
+ * quietly retire an id or change an answer — and every spec that puts a known
+ * card on screen would start failing for reasons that look like UI bugs. These
+ * run in Node against the same modules the app imports, so when the contract
+ * breaks it says so in one obvious place.
+ */
+import { expect, test } from '@playwright/test';
+import { ITEM, ORDER_SEQUENCE } from './harness';
+import { allItems, ITEMS_BY_ID } from '../../src/lib/generate';
+
+test.describe('content contract', () => {
+  test('the multiple-choice fixture is still a 4-option question with answer 50', () => {
+    const item = ITEMS_BY_ID.get(ITEM.mcq);
+    expect(item, `${ITEM.mcq} has left the item bank`).toBeDefined();
+    expect(item!.kind).toBe('mcq');
+    expect(item!.prompt).toBe('How many chapters are in Genesis?');
+    expect(item!.answer).toBe('50');
+    expect(item!.distractors).toContain('36');
+    expect(item!.distractors).toHaveLength(3);
+  });
+
+  test('the typed fixture still accepts the answer written out in words', () => {
+    const item = ITEMS_BY_ID.get(ITEM.type);
+    expect(item, `${ITEM.type} has left the item bank`).toBeDefined();
+    expect(item!.kind).toBe('type');
+    expect(item!.answer).toBe('66');
+    expect(item!.accepts).toContain('sixty-six');
+  });
+
+  test('the ordering fixture still holds the sequence the specs sort into', () => {
+    const item = ITEMS_BY_ID.get(ITEM.order);
+    expect(item, `${ITEM.order} has left the item bank`).toBeDefined();
+    expect(item!.kind).toBe('order');
+    expect(item!.sequence).toEqual(ORDER_SEQUENCE);
+  });
+
+  test('every item id is unique — SRS history is keyed on it', () => {
+    const items = allItems();
+    const seen = new Set<string>();
+    const duplicates = items.filter((i) => (seen.has(i.id) ? true : (seen.add(i.id), false)));
+    expect(duplicates.map((d) => d.id)).toEqual([]);
+    expect(items.length).toBeGreaterThan(6000);
+  });
+
+  test('no multiple-choice question hides its answer among the distractors', () => {
+    const broken = allItems().filter((i) => i.kind === 'mcq' && (i.distractors ?? []).includes(i.answer));
+    expect(broken.map((b) => b.id)).toEqual([]);
+  });
+});

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -1,0 +1,153 @@
+/**
+ * Seeding and reading helpers for the E2E build.
+ *
+ * The app under test runs with `E2E=1`, which swaps its Firestore transport for
+ * localStorage (see vite.config.ts). That is the whole seam: a test writes a
+ * Store before the page boots and reads it back afterwards, while every
+ * transition in between runs the app's real logic.
+ */
+import { expect, type Page } from '@playwright/test';
+import { E2E_AUTH_KEY, E2E_STORE_KEY } from '../../src/lib/e2e-keys';
+import type { CardState } from '../../src/lib/srs';
+import type { Store } from '../../src/lib/storage';
+
+export const DAY = 86_400_000;
+
+export const MEMBER = 'member@acts2.network';
+export const OUTSIDER = 'someone@gmail.com';
+
+/**
+ * Item ids that are stable across regeneration — one per question kind, so a
+ * test can put an exact card in front of itself. Kept honest by
+ * `content-contract.spec.ts`, which fails loudly if the bank stops producing them.
+ */
+export const ITEM = {
+  /** "How many chapters are in Genesis?" → 50 */
+  mcq: 'gen-chapters-genesis',
+  /** "How many books are in the Bible?" → 66, accepts "sixty-six" */
+  type: 'a-count-total',
+  /** "Put these events from Genesis 1–4 in the order they occur." */
+  order: 'det-ev-order-genesis-0',
+} as const;
+
+export const ORDER_SEQUENCE = ['Creation', 'The garden', 'The Fall', 'Cain and Abel'];
+
+/** ISO date `n` days from now — keeps the exam clamp away from wall-clock drift. */
+export function daysFromNow(n: number): string {
+  const d = new Date(Date.now() + n * DAY);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/** A card already in rotation and overdue, so it lands in today's queue. */
+export function dueCard(id: string, over: Partial<CardState> = {}): CardState {
+  return {
+    id,
+    ease: 2.5,
+    interval: 1,
+    reps: 2,
+    lapses: 0,
+    due: Date.now() - DAY,
+    lastSeen: Date.now() - 2 * DAY,
+    recent: [2, 2],
+    ...over,
+  };
+}
+
+/** A card that keeps being missed — four lapses is the leech threshold. */
+export function leechCard(id: string): CardState {
+  return dueCard(id, { lapses: 4, reps: 6, recent: [0, 0, 1, 0] });
+}
+
+export function storeWith(over: Partial<Store> = {}): Store {
+  return {
+    cards: {},
+    settings: { examDate: daysFromNow(60), newLimit: 20, sessionLimit: 60 },
+    log: [],
+    starred: [],
+    ...over,
+  };
+}
+
+interface SeedOptions {
+  /** Signed-in address; null leaves the app signed out. Defaults to a member. */
+  email?: string | null;
+  store?: Partial<Store>;
+  /** What the stubbed Google popup will do on the next click. */
+  nextSignIn?: string;
+}
+
+/**
+ * Writes auth + store into localStorage before any app code runs.
+ *
+ * Init scripts re-run on every navigation, so the write is guarded by a
+ * sentinel: the seed lands once, before the first load, and a reload or a
+ * sign-out then reflects what the app itself persisted rather than being
+ * silently reset to the seed.
+ */
+export async function seed(page: Page, options: SeedOptions = {}): Promise<void> {
+  const { email = MEMBER, store, nextSignIn } = options;
+  const payload = {
+    authKey: E2E_AUTH_KEY,
+    storeKey: E2E_STORE_KEY,
+    seededKey: 'e2e:seeded',
+    email,
+    store: JSON.stringify(storeWith(store)),
+    nextSignIn,
+  };
+  await page.addInitScript((data) => {
+    if (localStorage.getItem(data.seededKey)) return;
+    localStorage.setItem(data.seededKey, '1');
+    if (data.email) localStorage.setItem(data.authKey, data.email);
+    else localStorage.removeItem(data.authKey);
+    localStorage.setItem(data.storeKey, data.store);
+    if (data.nextSignIn) localStorage.setItem('e2e:next-sign-in', data.nextSignIn);
+  }, payload);
+}
+
+/** Navigate to a tab and wait out the boot splash's minimum hold. */
+export async function openApp(page: Page, tab = 'home'): Promise<void> {
+  await page.goto(`/#${tab}`);
+  await expect(page.locator('.boot-splash')).toBeHidden();
+}
+
+/** Seed a member, then open the app — the common two-line preamble. */
+export async function openAs(page: Page, options: SeedOptions = {}, tab = 'home'): Promise<void> {
+  await seed(page, options);
+  await openApp(page, tab);
+}
+
+/**
+ * A stat plate's figure. CountUp prints its number from a CSS counter, so the
+ * value is only in the accessible name — never in text content.
+ */
+export function statFigure(page: Page, label: string) {
+  return page
+    .locator('.stat')
+    .filter({ has: page.locator('.k', { hasText: new RegExp(`^${label}`) }) })
+    .locator('.count-up');
+}
+
+export async function expectStat(page: Page, label: string, value: number | string): Promise<void> {
+  await expect(statFigure(page, label)).toHaveAttribute('aria-label', String(value));
+}
+
+/** The store as the app last persisted it. */
+export async function readStore(page: Page, storeKey = E2E_STORE_KEY): Promise<Store> {
+  const raw = await page.evaluate((key) => localStorage.getItem(key), storeKey);
+  expect(raw, 'expected the app to have persisted a store').not.toBeNull();
+  return JSON.parse(raw!) as Store;
+}
+
+/** Days the header will count down for a given exam date — the app's own sum. */
+export function daysUntil(examDate: string): number {
+  return Math.max(0, Math.ceil((new Date(`${examDate}T23:59:59`).getTime() - Date.now()) / DAY));
+}
+
+/** Puts exactly one card in the review queue: one due, no new cards allowed. */
+export function soloQueue(id: string, over: Partial<Store> = {}): Partial<Store> {
+  return {
+    cards: { [id]: dueCard(id) },
+    settings: { examDate: daysFromNow(60), newLimit: 0, sessionLimit: 1 },
+    ...over,
+  };
+}

--- a/tests/e2e/library.spec.ts
+++ b/tests/e2e/library.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test, type Page } from '@playwright/test';
+import { openAs } from './harness';
+
+const search = (page: Page) => page.getByRole('textbox', { name: 'Search' });
+const section = (page: Page, label: string) => page.getByRole('radio', { name: label });
+
+test.describe('reference library', () => {
+  test('it opens on the books, grouped by division', async ({ page }) => {
+    await openAs(page, {}, 'library');
+
+    await expect(page.getByRole('heading', { name: /^Law/ })).toBeVisible();
+    await expect(page.getByRole('group').filter({ hasText: 'Genesis' }).first()).toBeVisible();
+    await expect(page.locator('.counts')).toContainText('66');
+  });
+
+  test('a book opens to its detail panel', async ({ page }) => {
+    await openAs(page, {}, 'library');
+
+    const genesis = page.locator('details.book').filter({ hasText: 'Genesis' }).first();
+    await genesis.getByRole('group').or(genesis.locator('summary')).first().click();
+
+    await expect(genesis).toHaveAttribute('open', '');
+    await expect(genesis.locator('.body')).toBeVisible();
+  });
+
+  test('search narrows the books and says by how much', async ({ page }) => {
+    await openAs(page, {}, 'library');
+
+    await search(page).fill('Melchizedek');
+
+    await expect(page.getByText(/book(s)? match “Melchizedek”/)).toBeVisible();
+    const shown = page.locator('details.book');
+    await expect(shown.first()).toBeVisible();
+    expect(await shown.count()).toBeLessThan(66);
+  });
+
+  test('search reaches into outlines and events, not just titles', async ({ page }) => {
+    await openAs(page, {}, 'library');
+
+    // "Babel" is nowhere in a book's name — only inside Genesis's event list.
+    await search(page).fill('Babel');
+
+    await expect(page.locator('details.book').filter({ hasText: 'Genesis' })).toHaveCount(1);
+  });
+
+  test('a search with no match says so instead of showing an empty page', async ({ page }) => {
+    await openAs(page, {}, 'library');
+
+    await search(page).fill('zzzznotathing');
+
+    await expect(page.getByText('No book mentions “zzzznotathing”. Try the People tab.')).toBeVisible();
+    await expect(page.locator('details.book')).toHaveCount(0);
+  });
+
+  test('the timeline lists every era in order', async ({ page }) => {
+    await openAs(page, {}, 'library');
+
+    await section(page, 'Timeline').click();
+
+    await expect(page.getByRole('heading', { name: '1. Creation & Early World' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '2. The Patriarchs' })).toBeVisible();
+    const eras = page.locator('.card').filter({ has: page.locator('.pill.accent') });
+    expect(await eras.count()).toBeGreaterThanOrEqual(14);
+  });
+
+  test('people and places are searchable tables', async ({ page }) => {
+    await openAs(page, {}, 'library');
+
+    await section(page, 'People & Places').click();
+    await expect(page.getByRole('heading', { name: /^People/ })).toBeVisible();
+
+    await search(page).fill('Melchizedek');
+
+    const peopleRows = page.locator('table.data').first().locator('tbody tr');
+    await expect(peopleRows).toHaveCount(1);
+    await expect(peopleRows).toContainText('Melchizedek');
+  });
+
+  test('the must-know lists show cue and content side by side', async ({ page }) => {
+    await openAs(page, {}, 'library');
+
+    await section(page, 'Lists to Know').click();
+
+    await expect(page.getByRole('heading', { name: 'Must-know lists' })).toBeVisible();
+    await expect(page.locator('.card-title').first()).toBeVisible();
+    await expect(page.locator('table.data tbody tr').first()).toBeVisible();
+  });
+
+  test('a search that only matches a list narrows the lists tab', async ({ page }) => {
+    await openAs(page, {}, 'library');
+
+    await section(page, 'Lists to Know').click();
+    await search(page).fill('Babel');
+
+    await expect(page.getByText(/list(s)? match “Babel”/)).toBeVisible();
+  });
+
+  test('the reference needs no review history to be useful', async ({ page }) => {
+    await openAs(page, { store: { cards: {}, log: [] } }, 'library');
+
+    await expect(page.locator('.counts')).toContainText('66');
+    await expect(page.locator('details.book')).toHaveCount(66);
+  });
+});

--- a/tests/e2e/mobile-gate.spec.ts
+++ b/tests/e2e/mobile-gate.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+import { openAs, seed } from './harness';
+
+/**
+ * Runs only under the `mobile` project (Pixel 5). The gate is a dead end by
+ * design — it must refuse *before* auth or the boot splash, so a member who
+ * cannot get in is never made to watch the press warm up.
+ */
+test.describe('mobile gate', () => {
+  test('a phone is refused in the app’s own voice', async ({ page }) => {
+    await openAs(page);
+
+    await expect(page.getByText('This trainer is built for a full keyboard and a wide screen')).toBeVisible();
+    await expect(page.getByText('Scripture Mastery')).toBeVisible();
+  });
+
+  test('the gate offers nothing to press and no way through', async ({ page }) => {
+    await openAs(page);
+
+    await expect(page.getByRole('button')).toHaveCount(0);
+    await expect(page.getByRole('navigation')).toBeHidden();
+    await expect(page.locator('.boot-splash')).toBeHidden();
+  });
+
+  test('it refuses a signed-out phone too, without showing the sign-in', async ({ page }) => {
+    await seed(page, { email: null });
+    await page.goto('/#home');
+
+    await expect(page.locator('.mobile-gate')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeHidden();
+  });
+
+  test('a deep link to a tab is gated the same way', async ({ page }) => {
+    await openAs(page, {}, 'quiz');
+
+    await expect(page.locator('.mobile-gate')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Mixed Quiz' })).toBeHidden();
+  });
+});

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test, type Page } from '@playwright/test';
+import { openAs } from './harness';
+
+/** Each tab, and the heading that proves it actually rendered. */
+const TABS = [
+  { label: 'Dashboard', hash: 'home', heading: 'Weakest areas' },
+  { label: 'Daily Review', hash: 'review', heading: 'Daily Review' },
+  { label: 'Quiz', hash: 'quiz', heading: 'Mixed Quiz' },
+  { label: 'Reference', hash: 'library', heading: 'Reference' },
+  { label: 'Study Plan', hash: 'plan', heading: 'Study Plan' },
+  { label: 'Progress', hash: 'progress', heading: 'Last 14 days' },
+];
+
+const tab = (page: Page, label: string) => page.getByRole('navigation').getByRole('button', { name: label });
+
+test.describe('navigation', () => {
+  for (const { label, hash, heading } of TABS) {
+    test(`the ${label} tab opens, marks itself current, and owns the hash`, async ({ page }) => {
+      await openAs(page);
+
+      await tab(page, label).click();
+
+      await expect(page.getByRole('heading', { name: heading })).toBeVisible();
+      await expect(page).toHaveURL(new RegExp(`#${hash}$`));
+      await expect(tab(page, label)).toHaveAttribute('aria-current', 'page');
+    });
+  }
+
+  test('only one tab is ever marked current', async ({ page }) => {
+    await openAs(page, {}, 'plan');
+    await expect(page.getByRole('button', { name: 'Study Plan' })).toHaveAttribute('aria-current', 'page');
+    await expect(page.locator('nav button[aria-current="page"]')).toHaveCount(1);
+  });
+
+  test('a deep link opens that tab directly', async ({ page }) => {
+    await openAs(page, {}, 'library');
+
+    await expect(page.getByRole('heading', { name: 'Reference' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Reference' })).toHaveAttribute('aria-current', 'page');
+  });
+
+  test('an unknown hash falls back to the dashboard rather than a blank screen', async ({ page }) => {
+    await openAs(page, {}, 'not-a-tab');
+
+    await expect(page.getByRole('heading', { name: 'Weakest areas' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Dashboard' })).toHaveAttribute('aria-current', 'page');
+  });
+
+  test('the back button returns to the previous tab', async ({ page }) => {
+    await openAs(page);
+
+    await tab(page, 'Quiz').click();
+    await expect(page.getByRole('heading', { name: 'Mixed Quiz' })).toBeVisible();
+    await tab(page, 'Study Plan').click();
+    await expect(page.getByRole('heading', { name: 'Study Plan' })).toBeVisible();
+
+    await page.goBack();
+
+    await expect(page.getByRole('heading', { name: 'Mixed Quiz' })).toBeVisible();
+    await expect(tab(page, 'Quiz')).toHaveAttribute('aria-current', 'page');
+  });
+
+  test('the dashboard call to action jumps to the review queue', async ({ page }) => {
+    await openAs(page);
+
+    await page.getByRole('button', { name: /review|Start today/i }).first().click();
+
+    await expect(page.getByRole('heading', { name: 'Daily Review' })).toBeVisible();
+    await expect(page).toHaveURL(/#review$/);
+  });
+});

--- a/tests/e2e/progress.spec.ts
+++ b/tests/e2e/progress.spec.ts
@@ -1,0 +1,162 @@
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { ITEM, daysFromNow, daysUntil, dueCard, expectStat, leechCard, openApp, openAs, readStore, seed, storeWith } from './harness';
+
+test.describe('progress and settings', () => {
+  test('session limits are editable and survive a reload', async ({ page }) => {
+    await openAs(page, {}, 'progress');
+
+    await page.locator('#nl').fill('35');
+    await page.locator('#sl').fill('120');
+
+    expect((await readStore(page)).settings).toMatchObject({ newLimit: 35, sessionLimit: 120 });
+
+    await page.reload();
+    await expect(page.locator('.boot-splash')).toBeHidden();
+    await expect(page.locator('#nl')).toHaveValue('35');
+    await expect(page.locator('#sl')).toHaveValue('120');
+  });
+
+  test('the quiz date drives the countdown in the header', async ({ page }) => {
+    await openAs(page, {}, 'progress');
+
+    await page.locator('#exam2').fill(daysFromNow(30));
+
+    await expect(page.locator('.countdown')).toContainText(`${daysUntil(daysFromNow(30))} days until`);
+    expect((await readStore(page)).settings.examDate).toBe(daysFromNow(30));
+  });
+
+  test('the study plan and Progress share one quiz date', async ({ page }) => {
+    await openAs(page, {}, 'plan');
+
+    await page.locator('#exam').fill(daysFromNow(45));
+
+    await page.getByRole('button', { name: 'Progress' }).click();
+    await expect(page.locator('#exam2')).toHaveValue(daysFromNow(45));
+  });
+
+  test('mastery by book reflects what has been answered', async ({ page }) => {
+    await openAs(page, { store: { cards: { [ITEM.mcq]: dueCard(ITEM.mcq, { recent: [3, 3, 3, 3], interval: 20 }) } } }, 'progress');
+
+    const genesisRow = page.locator('table.data tbody tr').filter({ hasText: 'Genesis' }).first();
+    await expect(genesisRow).toContainText('/');
+    await expect(genesisRow.getByRole('progressbar')).toHaveAttribute('aria-valuenow', /\d+/);
+  });
+
+  test('cards missed four times are surfaced as stuck, with their answers', async ({ page }) => {
+    await openAs(page, { store: { cards: { [ITEM.mcq]: leechCard(ITEM.mcq) } } }, 'progress');
+
+    await expect(page.getByRole('heading', { name: /Stuck items/ })).toBeVisible();
+    const stuckRow = page.locator('h2:has-text("Stuck items") ~ * table.data tbody tr');
+    await expect(stuckRow).toContainText('How many chapters are in Genesis?');
+    await expect(stuckRow).toContainText('50');
+  });
+
+  test('a clean history shows no stuck items at all', async ({ page }) => {
+    await openAs(page, {}, 'progress');
+
+    await expect(page.getByRole('heading', { name: /Stuck items/ })).toBeHidden();
+  });
+
+  test('export downloads the store as readable JSON', async ({ page }) => {
+    await openAs(page, { store: { cards: { [ITEM.mcq]: dueCard(ITEM.mcq) }, starred: [ITEM.type] } }, 'progress');
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: 'Export progress' }).click(),
+    ]);
+
+    expect(download.suggestedFilename()).toMatch(/^scripture-mastery-progress-\d{4}-\d{2}-\d{2}\.json$/);
+    const saved = JSON.parse(readFileSync(await download.path(), 'utf8'));
+    expect(saved.cards[ITEM.mcq].id).toBe(ITEM.mcq);
+    expect(saved.starred).toEqual([ITEM.type]);
+    expect(saved.settings).toHaveProperty('examDate');
+  });
+
+  test('import replaces the store and says so', async ({ page }) => {
+    await openAs(page, {}, 'progress');
+
+    const restored = storeWith({
+      cards: { [ITEM.mcq]: dueCard(ITEM.mcq, { reps: 9 }) },
+      starred: [ITEM.order],
+      log: [{ date: '2026-01-01', reviewed: 42, correct: 40 }],
+    });
+    await page.getByRole('button', { name: 'Import progress' }).click();
+    await page.locator('input[type=file]').setInputFiles({
+      name: 'backup.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify(restored)),
+    });
+
+    await expect(page.getByText('Progress restored.')).toBeVisible();
+    const store = await readStore(page);
+    expect(store.cards[ITEM.mcq].reps).toBe(9);
+    expect(store.starred).toEqual([ITEM.order]);
+  });
+
+  test('an unreadable import is refused without wiping what is there', async ({ page }) => {
+    await openAs(page, { store: { cards: { [ITEM.mcq]: dueCard(ITEM.mcq) } } }, 'progress');
+
+    await page.locator('input[type=file]').setInputFiles({
+      name: 'not-json.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from('this is not json at all'),
+    });
+
+    await expect(page.getByText('That file could not be read.')).toBeVisible();
+    expect((await readStore(page)).cards[ITEM.mcq]).toBeDefined();
+  });
+
+  test('reset asks first, and only then clears the history', async ({ page }) => {
+    await openAs(page, {
+      store: { cards: { [ITEM.mcq]: dueCard(ITEM.mcq) }, starred: [ITEM.type], log: [{ date: '2026-01-01', reviewed: 5, correct: 5 }] },
+    }, 'progress');
+
+    // Dismiss the confirm first — nothing should change.
+    page.once('dialog', (d) => d.dismiss());
+    await page.getByRole('button', { name: 'Reset progress' }).click();
+    expect((await readStore(page)).cards[ITEM.mcq]).toBeDefined();
+
+    page.once('dialog', (d) => {
+      expect(d.message()).toContain('Erase all review history');
+      return d.accept();
+    });
+    await page.getByRole('button', { name: 'Reset progress' }).click();
+
+    await expect(page.getByText('Progress cleared.')).toBeVisible();
+    const store = await readStore(page);
+    expect(store.cards).toEqual({});
+    expect(store.log).toEqual([]);
+    expect(store.starred).toEqual([]);
+    // Settings are preserved — a reset is not a factory wipe.
+    expect(store.settings).toHaveProperty('examDate');
+  });
+
+  test('the 14-day chart always shows a fortnight, gaps included', async ({ page }) => {
+    await seed(page, { store: { log: [{ date: daysFromNow(0), reviewed: 12, correct: 10 }] } });
+    await openApp(page, 'progress');
+
+    await expect(page.getByRole('heading', { name: 'Last 14 days' })).toBeVisible();
+    await expect(page.locator('.card [title$="answered"]')).toHaveCount(14);
+  });
+
+  test('the dashboard streak counts consecutive days of study', async ({ page }) => {
+    await openAs(page, {
+      store: {
+        log: [-2, -1, 0].map((back) => ({ date: daysFromNow(back), reviewed: 5, correct: 5 })),
+      },
+    });
+
+    await expectStat(page, 'Consecutive days', 3);
+  });
+
+  test('a broken streak resets the count', async ({ page }) => {
+    await openAs(page, {
+      store: {
+        log: [-5, 0].map((back) => ({ date: daysFromNow(back), reviewed: 5, correct: 5 })),
+      },
+    });
+
+    await expectStat(page, 'Consecutive days', 1);
+  });
+});

--- a/tests/e2e/question-kinds.spec.ts
+++ b/tests/e2e/question-kinds.spec.ts
@@ -1,0 +1,206 @@
+import { expect, test, type Page } from '@playwright/test';
+import { ITEM, ORDER_SEQUENCE, openAs, readStore, soloQueue } from './harness';
+
+/** A choice button by its option text — `.choice` also holds the 1-4 key label. */
+const choice = (page: Page, label: string) =>
+  page.locator('.choice').filter({ has: page.getByText(label, { exact: true }) });
+
+/** Opens Daily Review with exactly one card queued: the given item. */
+async function reviewOne(page: Page, id: string) {
+  await openAs(page, { store: soloQueue(id) }, 'review');
+  await page.getByRole('button', { name: 'Start review session' }).click();
+}
+
+/** Drag-free sort: walk each entry up until the list matches `want`. */
+async function arrangeInto(page: Page, want: string[]) {
+  const rows = page.locator('.order-item');
+  for (let target = 0; target < want.length; target++) {
+    for (;;) {
+      const labels = await rows.locator('span:not(.num):not(.moves)').allInnerTexts();
+      const at = labels.indexOf(want[target]);
+      if (at <= target) break;
+      await rows.nth(at).getByRole('button', { name: 'Move up' }).click();
+    }
+  }
+}
+
+async function currentOrder(page: Page): Promise<string[]> {
+  return page.locator('.order-item span:not(.num):not(.moves)').allInnerTexts();
+}
+
+test.describe('multiple choice', () => {
+  test('a right answer reveals the grade buttons and records the card', async ({ page }) => {
+    await reviewOne(page, ITEM.mcq);
+
+    await expect(page.getByText('How many chapters are in Genesis?')).toBeVisible();
+    await expect(page.locator('.choice')).toHaveCount(4);
+    await choice(page, '50').click();
+
+    await expect(page.locator('.feedback.correct')).toContainText('Correct');
+    await expect(page.getByRole('button', { name: /^Good/ })).toBeVisible();
+    await page.getByRole('button', { name: /^Good/ }).click();
+
+    const store = await readStore(page);
+    expect(store.cards[ITEM.mcq].reps).toBe(3);
+    expect(store.log.at(-1)).toMatchObject({ reviewed: 1, correct: 1 });
+  });
+
+  test('a wrong answer shows the right one and marks both options', async ({ page }) => {
+    await reviewOne(page, ITEM.mcq);
+
+    await choice(page, '36').click();
+
+    await expect(page.locator('.feedback.wrong')).toContainText('Not quite');
+    await expect(page.locator('.feedback')).toContainText('Answer: 50');
+    await expect(page.locator('.choice.correct')).toHaveText(/50/);
+    await expect(page.locator('.choice.wrong')).toHaveText(/36/);
+    // A miss offers no self-grading — it goes back in the queue as "again".
+    await expect(page.getByRole('button', { name: /^Good/ })).toBeHidden();
+    await expect(page.getByRole('button', { name: /^Continue/ })).toBeVisible();
+  });
+
+  test('every option locks once an answer is in', async ({ page }) => {
+    await reviewOne(page, ITEM.mcq);
+
+    await choice(page, '36').click();
+
+    for (const choice of await page.locator('.choice').all()) {
+      await expect(choice).toBeDisabled();
+    }
+  });
+
+  test('number keys pick an option, then grade it', async ({ page }) => {
+    await reviewOne(page, ITEM.mcq);
+
+    // Options are reshuffled per item, so find where the right answer landed.
+    const labels = await page.locator('.choice span:not(.key)').allInnerTexts();
+    const slot = labels.indexOf('50');
+    expect(slot, 'the correct option should be on screen').toBeGreaterThanOrEqual(0);
+
+    await page.keyboard.press(String(slot + 1));
+    await expect(page.locator('.feedback.correct')).toBeVisible();
+
+    await page.keyboard.press('3'); // Easy
+    const store = await readStore(page);
+    // Easy nudges ease up from the 2.5 default; Good would have left it alone.
+    expect(store.cards[ITEM.mcq].ease).toBeCloseTo(2.6, 5);
+    expect(store.cards[ITEM.mcq].recent.at(-1)).toBe(3);
+  });
+});
+
+test.describe('typed answers', () => {
+  test('the matcher accepts the answer spelled out in words', async ({ page }) => {
+    await reviewOne(page, ITEM.type);
+
+    await expect(page.getByText('How many books are in the Bible?')).toBeVisible();
+    await page.locator('input.answer').fill('sixty-six');
+    await page.keyboard.press('Enter');
+
+    await expect(page.locator('.feedback.correct')).toContainText('Correct');
+  });
+
+  test('the Check button and Enter do the same thing', async ({ page }) => {
+    await reviewOne(page, ITEM.type);
+
+    await page.locator('input.answer').fill('66');
+    await page.getByRole('button', { name: 'Check' }).click();
+
+    await expect(page.locator('.feedback.correct')).toBeVisible();
+    await expect(page.locator('input.answer')).toBeDisabled();
+  });
+
+  test('a genuinely wrong answer is refused', async ({ page }) => {
+    await reviewOne(page, ITEM.type);
+
+    await page.locator('input.answer').fill('12');
+    await page.keyboard.press('Enter');
+
+    await expect(page.locator('.feedback.wrong')).toContainText('Not quite');
+    await expect(page.locator('.feedback')).toContainText('Answer: 66');
+  });
+
+  test('an empty submission is not counted as correct', async ({ page }) => {
+    await reviewOne(page, ITEM.type);
+
+    await page.keyboard.press('Enter');
+
+    await expect(page.locator('.feedback.wrong')).toBeVisible();
+  });
+
+  test('"I had it right" overrides a miss and logs it as correct', async ({ page }) => {
+    await reviewOne(page, ITEM.type);
+
+    await page.locator('input.answer').fill('twelve');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('.feedback.wrong')).toBeVisible();
+
+    await page.getByRole('button', { name: 'I had it right' }).click();
+
+    const store = await readStore(page);
+    expect(store.log.at(-1)).toMatchObject({ reviewed: 1, correct: 1 });
+    expect(store.cards[ITEM.type].lapses).toBe(0);
+  });
+});
+
+test.describe('ordering', () => {
+  test('the entries can be sorted into the right sequence', async ({ page }) => {
+    await reviewOne(page, ITEM.order);
+
+    await expect(page.getByText('Put these events from Genesis 1–4 in the order they occur.')).toBeVisible();
+    await expect(page.locator('.order-item')).toHaveCount(ORDER_SEQUENCE.length);
+
+    await arrangeInto(page, ORDER_SEQUENCE);
+    expect(await currentOrder(page)).toEqual(ORDER_SEQUENCE);
+
+    await page.getByRole('button', { name: 'Check order' }).click();
+
+    await expect(page.locator('.feedback.correct')).toContainText('Correct');
+    await expect(page.locator('.order-item.wrong')).toHaveCount(0);
+  });
+
+  test('a wrong sequence is marked entry by entry and the answer spelled out', async ({ page }) => {
+    await reviewOne(page, ITEM.order);
+
+    // Force a known-wrong arrangement: exact reverse of the correct sequence.
+    await arrangeInto(page, [...ORDER_SEQUENCE].reverse());
+    await page.getByRole('button', { name: 'Check order' }).click();
+
+    await expect(page.locator('.feedback.wrong')).toContainText('Not quite');
+    await expect(page.locator('.feedback')).toContainText(ORDER_SEQUENCE.join(' → '));
+    await expect(page.locator('.order-item.wrong')).toHaveCount(ORDER_SEQUENCE.length);
+  });
+
+  test('the move buttons stop at the ends of the list', async ({ page }) => {
+    await reviewOne(page, ITEM.order);
+
+    const rows = page.locator('.order-item');
+    await expect(rows.first().getByRole('button', { name: 'Move up' })).toBeDisabled();
+    await expect(rows.last().getByRole('button', { name: 'Move down' })).toBeDisabled();
+  });
+
+  test('Enter submits the arrangement', async ({ page }) => {
+    await reviewOne(page, ITEM.order);
+
+    await arrangeInto(page, ORDER_SEQUENCE);
+    await page.keyboard.press('Enter');
+
+    await expect(page.locator('.feedback.correct')).toBeVisible();
+  });
+});
+
+test.describe('starring', () => {
+  test('a card can be starred and unstarred from the question', async ({ page }) => {
+    await reviewOne(page, ITEM.mcq);
+
+    const star = page.getByRole('button', { name: 'Star for focused review' });
+    await expect(star).toHaveAttribute('aria-pressed', 'false');
+    await star.click();
+
+    const starred = page.getByRole('button', { name: 'Unstar this question' });
+    await expect(starred).toHaveAttribute('aria-pressed', 'true');
+    expect((await readStore(page)).starred).toEqual([ITEM.mcq]);
+
+    await starred.click();
+    expect((await readStore(page)).starred).toEqual([]);
+  });
+});

--- a/tests/e2e/quiz.spec.ts
+++ b/tests/e2e/quiz.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test, type Page } from '@playwright/test';
+import { DAY, ITEM, daysFromNow, dueCard, expectStat, openAs, readStore } from './harness';
+
+const poolCount = (page: Page) => page.getByText(/questions? match(es)? this filter/);
+const scope = (page: Page, label: string) => page.getByRole('radio', { name: label });
+/** Card titles are styled divs, not headings — locate them by class. */
+const cardTitle = (page: Page, text: string) => page.locator('.card-title', { hasText: text });
+
+/** Reads the "6,581 questions across 66 books" figure out of the header. */
+async function bankSize(page: Page): Promise<number> {
+  const tagline = await page.locator('.brand span').innerText();
+  return Number(tagline.replace(/,/g, '').match(/\d+/)![0]);
+}
+
+test.describe('mixed quiz', () => {
+  test('the unfiltered pool is the whole item bank', async ({ page }) => {
+    await openAs(page, {}, 'quiz');
+
+    await expect(poolCount(page)).toContainText(`${await bankSize(page)} questions`);
+    await expect(page.getByRole('button', { name: 'Start quiz' })).toBeEnabled();
+  });
+
+  test('narrowing to one book shrinks the pool', async ({ page }) => {
+    await openAs(page, {}, 'quiz');
+    const everything = await bankSize(page);
+
+    await page.selectOption('#book', 'genesis');
+
+    const narrowed = Number((await poolCount(page).innerText()).replace(/,/g, '').match(/\d+/)![0]);
+    expect(narrowed).toBeGreaterThan(0);
+    expect(narrowed).toBeLessThan(everything);
+  });
+
+  test('topic and book filters compose', async ({ page }) => {
+    await openAs(page, {}, 'quiz');
+
+    await page.selectOption('#book', 'genesis');
+    const bookOnly = Number((await poolCount(page).innerText()).replace(/,/g, '').match(/\d+/)![0]);
+    await page.selectOption('#topic', 'events');
+    const both = Number((await poolCount(page).innerText()).replace(/,/g, '').match(/\d+/)![0]);
+
+    expect(both).toBeLessThanOrEqual(bookOnly);
+  });
+
+  test('a scope with nothing in it cannot be started', async ({ page }) => {
+    await openAs(page, {}, 'quiz');
+
+    await scope(page, 'Starred').click();
+
+    await expect(poolCount(page)).toContainText('0 questions');
+    await expect(page.getByRole('button', { name: 'Start quiz' })).toBeDisabled();
+  });
+
+  test('a quiz runs to results, and what was missed is listed with its answer', async ({ page }) => {
+    await openAs(page, { store: { starred: [ITEM.mcq] } }, 'quiz');
+
+    await scope(page, 'Starred').click();
+    // Grammar note: the app renders "1 question match this filter".
+    await expect(poolCount(page)).toContainText(/^1 question match/);
+    await page.getByRole('button', { name: 'Start quiz' }).click();
+
+    await expect(page.getByRole('progressbar', { name: 'Progress: question 1 of 1' })).toBeVisible();
+    await page.locator('.choice').filter({ has: page.getByText('36', { exact: true }) }).click();
+    await page.getByRole('button', { name: /^Continue/ }).click();
+
+    await expect(cardTitle(page, 'Quiz complete')).toBeVisible();
+    await expectStat(page, 'correct out of 1', 0);
+    await expect(page.getByText('What you missed')).toBeVisible();
+
+    const missedRow = page.locator('table.data tbody tr');
+    await expect(missedRow).toHaveCount(1);
+    await expect(missedRow).toContainText('How many chapters are in Genesis?');
+    await expect(missedRow).toContainText('50');
+  });
+
+  test('a clean run reports full marks and lists nothing missed', async ({ page }) => {
+    await openAs(page, { store: { starred: [ITEM.mcq] } }, 'quiz');
+
+    await scope(page, 'Starred').click();
+    await page.getByRole('button', { name: 'Start quiz' }).click();
+    await page.locator('.choice').filter({ has: page.getByText('50', { exact: true }) }).click();
+    await page.getByRole('button', { name: /^Good/ }).click();
+
+    await expect(cardTitle(page, 'Quiz complete')).toBeVisible();
+    await expectStat(page, 'correct out of 1', 1);
+    await expect(page.getByText('100% correct')).toBeVisible();
+    await expect(page.getByText('What you missed')).toBeHidden();
+  });
+
+  test('results offer a retake and a way back to the filters', async ({ page }) => {
+    await openAs(page, { store: { starred: [ITEM.mcq] } }, 'quiz');
+    await scope(page, 'Starred').click();
+    await page.getByRole('button', { name: 'Start quiz' }).click();
+    await page.locator('.choice').filter({ has: page.getByText('50', { exact: true }) }).click();
+    await page.getByRole('button', { name: /^Good/ }).click();
+
+    await page.getByRole('button', { name: 'Retake' }).click();
+    await expect(page.getByRole('progressbar', { name: 'Progress: question 1 of 1' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Quit quiz' }).click();
+    await expect(cardTitle(page, 'Choose what to cover')).toBeVisible();
+  });
+
+  test('weak spots only draws on cards already seen and not yet known', async ({ page }) => {
+    await openAs(page, {
+      store: {
+        cards: {
+          // Missed repeatedly — weak.
+          [ITEM.mcq]: dueCard(ITEM.mcq, { recent: [0, 0, 1, 0], interval: 1 }),
+          // Answered easily and spaced far out — strong.
+          [ITEM.type]: dueCard(ITEM.type, { recent: [3, 3, 3, 3], interval: 30, due: Date.now() + 20 * DAY }),
+        },
+      },
+    }, 'quiz');
+
+    await scope(page, 'Weak spots').click();
+
+    await expect(poolCount(page)).toContainText(/^1 question match/);
+    await page.getByRole('button', { name: 'Start quiz' }).click();
+    await expect(page.getByText('How many chapters are in Genesis?')).toBeVisible();
+  });
+
+  test('quiz answers feed the same review schedule', async ({ page }) => {
+    await openAs(page, { store: { starred: [ITEM.mcq], settings: { examDate: daysFromNow(60), newLimit: 20, sessionLimit: 60 } } }, 'quiz');
+
+    await scope(page, 'Starred').click();
+    await page.getByRole('button', { name: 'Start quiz' }).click();
+    await page.locator('.choice').filter({ has: page.getByText('50', { exact: true }) }).click();
+    await page.getByRole('button', { name: /^Good/ }).click();
+    await expect(cardTitle(page, 'Quiz complete')).toBeVisible();
+
+    const store = await readStore(page);
+    expect(store.cards[ITEM.mcq]).toMatchObject({ reps: 1, lapses: 0 });
+    expect(store.cards[ITEM.mcq].due).toBeGreaterThan(Date.now());
+    expect(store.log.at(-1)).toMatchObject({ reviewed: 1, correct: 1 });
+  });
+
+  test('the scope control keeps the arrow-key contract of a radio group', async ({ page }) => {
+    await openAs(page, {}, 'quiz');
+
+    await scope(page, 'Everything').click();
+    await expect(scope(page, 'Everything')).toHaveAttribute('aria-checked', 'true');
+
+    await page.keyboard.press('ArrowRight');
+
+    await expect(scope(page, 'Old Testament')).toHaveAttribute('aria-checked', 'true');
+    await expect(scope(page, 'Everything')).toHaveAttribute('aria-checked', 'false');
+  });
+});

--- a/tests/e2e/review.spec.ts
+++ b/tests/e2e/review.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test, type Page } from '@playwright/test';
+import { DAY, ITEM, daysFromNow, dueCard, expectStat, openAs, readStore, soloQueue } from './harness';
+
+const start = (page: Page) => page.getByRole('button', { name: 'Start review session' }).click();
+
+/** Answer whatever is on screen correctly, if it is the MCQ we seeded. */
+async function answerMcq(page: Page, label: string) {
+  await page.locator('.choice').filter({ has: page.getByText(label, { exact: true }) }).click();
+}
+
+test.describe('daily review', () => {
+  test('the idle screen counts what is due, what is new, and what has been seen', async ({ page }) => {
+    const cards = {
+      [ITEM.mcq]: dueCard(ITEM.mcq),
+      [ITEM.type]: dueCard(ITEM.type),
+      // Not due for a week — should count as seen but not as due.
+      [ITEM.order]: dueCard(ITEM.order, { due: Date.now() + 7 * DAY }),
+    };
+    await openAs(page, { store: { cards, settings: { examDate: daysFromNow(60), newLimit: 5, sessionLimit: 60 } } }, 'review');
+
+    await expectStat(page, 'Due now', 2);
+    await expectStat(page, 'New today', 5); // capped by the new-card limit
+    await expectStat(page, 'Seen so far', 3);
+  });
+
+  test('a session runs from first card to summary and logs what happened', async ({ page }) => {
+    await openAs(page, { store: soloQueue(ITEM.mcq) }, 'review');
+    await start(page);
+
+    await expect(page.getByRole('progressbar', { name: '0 of 1 answered' })).toBeVisible();
+    await expect(page.getByText('1 / 1')).toBeVisible();
+
+    await answerMcq(page, '50');
+    await page.getByRole('button', { name: /^Good/ }).click();
+
+    await expect(page.getByRole('heading', { name: 'Session complete' })).toBeVisible();
+    await expectStat(page, 'Answered', 1);
+    await expectStat(page, 'Correct', 1);
+    await expectStat(page, 'Accuracy', 100);
+
+    const store = await readStore(page);
+    expect(store.log.at(-1)).toMatchObject({ reviewed: 1, correct: 1 });
+  });
+
+  test('a missed card is requeued and asked again — currently it comes back pre-answered', async ({ page }) => {
+    // KNOWN BUG (src/views/Review.tsx:127): the session card is keyed on
+    // `item.id`, so when a missed card is requeued as the *very next* card —
+    // which is what happens whenever you miss the last card of a session —
+    // React reuses the component and QuestionCard's reset effect, keyed on the
+    // same `item.id`, never fires. The card returns still revealed, with the
+    // wrong answer in a disabled input: no retrieval, which is the entire point
+    // of requeueing it. Keying on the queue position instead fixes it.
+    // Delete this `test.fail()` once it is fixed — Playwright will flag the
+    // test as unexpectedly passing.
+    test.fail();
+
+    await openAs(page, { store: soloQueue(ITEM.mcq) }, 'review');
+    await start(page);
+
+    await answerMcq(page, '36');
+    await page.getByRole('button', { name: /^Continue/ }).click();
+
+    // The card is back — it should be asked afresh, not shown already answered.
+    await expect(page.getByText('How many chapters are in Genesis?')).toBeVisible();
+    await expect(page.locator('.feedback')).toHaveCount(0);
+    await expect(page.locator('.choice').first()).toBeEnabled();
+  });
+
+  test('a missed card comes back twice at most, then the session ends', async ({ page }) => {
+    await openAs(page, { store: soloQueue(ITEM.mcq) }, 'review');
+    await start(page);
+
+    // Miss it three times; the third must not extend the session again.
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      await expect(page.getByText('How many chapters are in Genesis?')).toBeVisible();
+      // Tolerates the requeue bug above: only answer if the card is still open.
+      if (await page.locator('.feedback').count() === 0) await answerMcq(page, '36');
+      await page.getByRole('button', { name: /^Continue/ }).click();
+    }
+
+    await expect(page.getByRole('heading', { name: 'Session complete' })).toBeVisible();
+    await expectStat(page, 'Answered', 3);
+    await expectStat(page, 'Correct', 0);
+    await expectStat(page, 'Accuracy', 0);
+
+    const store = await readStore(page);
+    expect(store.cards[ITEM.mcq].lapses).toBe(3);
+    // "Again" schedules a same-session repeat, not a day away.
+    expect(store.cards[ITEM.mcq].interval).toBe(0);
+  });
+
+  test('the running tally updates as the session goes', async ({ page }) => {
+    const cards = { [ITEM.mcq]: dueCard(ITEM.mcq), [ITEM.type]: dueCard(ITEM.type) };
+    await openAs(page, { store: { cards, settings: { examDate: daysFromNow(60), newLimit: 0, sessionLimit: 2 } } }, 'review');
+    await start(page);
+
+    await expect(page.getByText('0 right · 0 missed')).toBeVisible();
+    await expect(page.getByRole('progressbar', { name: '0 of 2 answered' })).toBeVisible();
+  });
+
+  test('ending a session early returns to the idle screen', async ({ page }) => {
+    await openAs(page, { store: soloQueue(ITEM.mcq) }, 'review');
+    await start(page);
+
+    await page.getByRole('button', { name: 'End session' }).click();
+
+    await expect(page.getByRole('button', { name: 'Start review session' })).toBeVisible();
+    await expect(page.locator('.card-swap')).toBeHidden();
+  });
+
+  test('another session can be started from the summary', async ({ page }) => {
+    await openAs(page, { store: soloQueue(ITEM.mcq) }, 'review');
+    await start(page);
+    await answerMcq(page, '50');
+    await page.getByRole('button', { name: /^Good/ }).click();
+
+    await expect(page.getByRole('heading', { name: 'Session complete' })).toBeVisible();
+    await page.getByRole('button', { name: 'Done' }).click();
+
+    await expect(page.getByRole('button', { name: 'Start review session' })).toBeVisible();
+  });
+
+  test('review intervals never outrun the quiz date', async ({ page }) => {
+    // Exam in 10 days: an "easy" grade must land inside it, not the ~7 days
+    // SM-2 would otherwise give a card with a 3-day interval.
+    await openAs(page, {
+      store: {
+        cards: { [ITEM.mcq]: dueCard(ITEM.mcq, { interval: 3, ease: 2.5 }) },
+        settings: { examDate: daysFromNow(10), newLimit: 0, sessionLimit: 1 },
+      },
+    }, 'review');
+    await start(page);
+
+    await answerMcq(page, '50');
+    await page.getByRole('button', { name: /^Easy/ }).click();
+
+    const store = await readStore(page);
+    const card = store.cards[ITEM.mcq];
+    expect(card.interval).toBeLessThanOrEqual(6); // half the days remaining
+    expect(card.due).toBeLessThan(new Date(`${daysFromNow(10)}T23:59:59`).getTime());
+  });
+});

--- a/tests/e2e/shell.spec.ts
+++ b/tests/e2e/shell.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+import { MEMBER, OUTSIDER, expectStat, openApp, openAs, seed } from './harness';
+
+test.describe('shell and auth', () => {
+  test('a signed-out visitor gets the sign-in prompt, not the app', async ({ page }) => {
+    await openAs(page, { email: null });
+
+    await expect(page.getByText('Sign in with your acts2.network or gpmail.org account to begin.')).toBeVisible();
+    await expect(page.getByRole('navigation')).toBeHidden();
+    await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
+  });
+
+  test('signing in swaps the prompt for the dashboard', async ({ page }) => {
+    await openAs(page, { email: null });
+
+    await page.getByRole('button', { name: 'Sign in with Google' }).click();
+
+    await expect(page.getByRole('button', { name: 'Dashboard' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Weakest areas' })).toBeVisible();
+  });
+
+  test('a dismissed popup surfaces the error and keeps the prompt up', async ({ page }) => {
+    await openAs(page, { email: null, nextSignIn: 'cancel' });
+
+    await page.getByRole('button', { name: 'Sign in with Google' }).click();
+
+    await expect(page.getByText('The sign-in popup was closed before completing.')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
+  });
+
+  test('an off-domain account is refused by name and offered a way out', async ({ page }) => {
+    await openAs(page, { email: OUTSIDER });
+
+    await expect(
+      page.getByText(`${OUTSIDER} isn’t on an allowed domain. Sign in with acts2.network or gpmail.org instead.`),
+    ).toBeVisible();
+    await expect(page.getByRole('navigation')).toBeHidden();
+
+    await page.getByRole('button', { name: 'Sign out' }).click();
+    await expect(page.getByText('Sign in with your acts2.network or gpmail.org account to begin.')).toBeVisible();
+  });
+
+  test('the boot splash holds, then hands off to the app', async ({ page }) => {
+    await seed(page, { email: MEMBER });
+    await page.goto('/#home');
+
+    const splash = page.locator('.boot-splash');
+    await expect(splash).toHaveAttribute('aria-label', 'Scripture Mastery — Loading…');
+    await expect(splash).toBeHidden();
+    await expect(page.getByRole('navigation')).toBeVisible();
+  });
+
+  test('the header counts down to the seeded quiz date', async ({ page }) => {
+    await openAs(page, { store: { settings: { examDate: '2027-03-04', newLimit: 20, sessionLimit: 60 } } });
+
+    const days = Math.max(0, Math.ceil((new Date('2027-03-04T23:59:59').getTime() - Date.now()) / 86_400_000));
+    await expect(page.locator('.countdown')).toHaveText(`${days.toLocaleString()} days until March 4`);
+    await expectStat(page, 'Days to quiz', days);
+  });
+
+  test('signing out from the header returns to the prompt', async ({ page }) => {
+    await openAs(page);
+
+    await page.locator('header').getByRole('button', { name: 'Sign out' }).click();
+
+    await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
+    await expect(page.getByRole('navigation')).toBeHidden();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,43 @@
-import { defineConfig } from 'vite';
+import { fileURLToPath } from 'node:url';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 
+/** Set by `npm run dev:e2e`, which is all Playwright ever starts. */
+const isE2E = process.env.E2E === '1';
+
+/**
+ * Swaps the Firestore-backed store and the Firebase entry point for their
+ * localStorage stand-ins, so Playwright can drive the whole app without an
+ * auth popup or an emulator.
+ *
+ * It matches on the *resolved* file rather than the import specifier, so it
+ * catches './lib/useStore' and '../lib/useStore' alike and cannot be defeated
+ * by a future file moving a directory. Active only under E2E=1 — a production
+ * build never loads this plugin, so the stand-ins cannot reach real users.
+ */
+function e2eStandIns(): Plugin {
+  const standIn = (name: string) =>
+    fileURLToPath(new URL(`./src/lib/${name}.e2e.ts`, import.meta.url));
+  const swaps: Record<string, string> = {
+    '/src/lib/useStore.ts': standIn('useStore'),
+    '/src/lib/firebase.ts': standIn('firebase'),
+  };
+
+  return {
+    name: 'e2e-stand-ins',
+    enforce: 'pre',
+    async resolveId(source, importer, options) {
+      if (!importer || source.includes('.e2e')) return null;
+      const resolved = await this.resolve(source, importer, { ...options, skipSelf: true });
+      if (!resolved) return null;
+      const hit = Object.keys(swaps).find((suffix) => resolved.id.endsWith(suffix));
+      return hit ? swaps[hit] : null;
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), ...(isE2E ? [e2eStandIns()] : [])],
   base: './',
-  server: { port: 5173, open: true },
+  server: { port: 5173, open: !isE2E },
 });


### PR DESCRIPTION
82 browser tests over the parts of the app that were previously untested — which was all of them.

## What it covers

| Spec | Covers |
|---|---|
| `shell.spec.ts` | sign-in, dismissed popup, off-domain refusal, splash handoff, countdown, sign-out |
| `navigation.spec.ts` | all six tabs, hash routing, deep links, unknown-hash fallback, back button |
| `question-kinds.spec.ts` | MCQ + keyboard `1`–`4`/grade keys, the type-in fuzzy matcher, "I had it right", ordering, starring |
| `review.spec.ts` | due/new/seen counts, session → summary, requeue cap, exam-date interval clamp |
| `quiz.spec.ts` | filter composition, empty scope, missed-answers table, weak spots, radiogroup arrow keys |
| `library.spec.ts` | search into outlines and events, no-match copy, timeline, people tables, must-know lists |
| `progress.spec.ts` | settings persistence, export download, import round-trip, reset confirm, streaks, leeches |
| `mobile-gate.spec.ts` | Pixel 5 project — the refusal, and that nothing leaks through it |
| `content-contract.spec.ts` | pins the three fixture item ids so bank changes fail in one obvious place |

## Getting past Google sign-in

Every screen but the splash sits behind a Firebase popup, and the emulators need a JVM. So the E2E build swaps two modules and nothing else — `useStore.ts` and `firebase.ts` become `*.e2e.ts` stand-ins keeping the store in localStorage — through a vite plugin gated on `E2E=1`. A production build never loads the plugin; I verified its output contains zero E2E code and still ships the real Firebase SDK.

To keep that from testing a fake, the pure transitions move out of `useStore` into `src/lib/store-ops.ts`, which **both** hooks call. The stand-in replaces the transport only — grading, logging and the exam clamp are the real code either way. It declares `StoreApi` as its return type, so it cannot drift from the real hook without failing `tsc`.

Tests seed a whole `Store` into localStorage before boot and read it back after. Where a test needs a known question on screen it seeds one due card with `newLimit: 0`, so the queue can only hold that one — no shuffling, no flake.

## Two things this turned up

**A real bug, left unfixed and recorded as a `test.fail()`.** Miss the last card of a session and it is requeued — but comes back already answered, wrong answer still sitting in a disabled input. `src/views/Review.tsx:127` keys the card on `item.id`, so when the same id repeats back to back React reuses the component and `QuestionCard`'s reset effect, keyed on that same id, never fires. You are never actually re-asked, which is the entire point of requeueing. Keying on queue position fixes it; delete the marker and Playwright will flag the test as unexpectedly passing.

**A footgun in `npm run check`.** It was `tsc -b --noEmit false`, which overrode the tsconfig's `noEmit` and emitted ~43 compiled `.js` files into `src/`. Vite then resolved `./lib/useStore` to the stale `useStore.js` and silently served the wrong code. Now `tsc -b --pretty`.

## CI

`.github/workflows/ci.yml` runs typecheck → content validation → browser tests on every PR. It needs **no secrets**, because the E2E build has no Firebase in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)