### PR TITLE
Remove chapter-count questions from Numbers & Counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Removed
+
+- **Chapter-count questions** ([#8]). The 66 per-book "How many chapters are in
+  X?" items are gone, along with "How many chapters are in the whole Bible?"
+  (1,189) — the same species of question in the same topic. Their answer is a
+  number you read off a contents page, which teaches nothing about the book.
+  The Numbers & Counts topic keeps its other 256 items, including the questions
+  where chapters are only incidental and the answer is a *name* ("What is the
+  longest chapter in the Bible?" → Psalm 119). Bank is now 6,514 items and
+  every book still clears the 20-question floor.
+
+### Fixed
+
+- **A race in the e2e ordering helper.** `arrangeInto` re-read the list
+  immediately after clicking "Move up", so under load it could compute an index
+  from the pre-click DOM and walk the wrong row. It now waits for each row to
+  land before re-reading, and asserts the finished arrangement — one caller
+  submitted an arrangement without ever checking it, turning the race into a
+  confusing count mismatch three assertions later.
+
 ### Added
 
 - **App icon** ([#7]). The "Blade on the page" mark (design 2a) — a paper ribbon
@@ -19,3 +39,5 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   SVG loaded as a favicon never sees the document's custom properties.
 
 [#7]: https://github.com/godwinlaw/scripture-mastery/issues/7
+
+[#8]: https://github.com/godwinlaw/scripture-mastery/issues/8

--- a/src/data/extras.ts
+++ b/src/data/extras.ts
@@ -77,7 +77,11 @@ export const AUTHORED: Item[] = [
   { id: 'a-count-total', kind: 'type', topic: 'numbers', tier: 1, prompt: 'How many books are in the Bible?', answer: '66', accepts: ['sixty-six', 'sixty six'], explain: '39 Old Testament + 27 New Testament = 66. (39 × 27 is a handy check: 3 × 9 = 27.)' },
   { id: 'a-count-ot', kind: 'type', topic: 'numbers', tier: 1, prompt: 'How many books are in the Old Testament?', answer: '39', accepts: ['thirty-nine', 'thirty nine'] },
   { id: 'a-count-nt', kind: 'type', topic: 'numbers', tier: 1, prompt: 'How many books are in the New Testament?', answer: '27', accepts: ['twenty-seven', 'twenty seven'] },
-  { id: 'a-count-chapters', kind: 'mcq', topic: 'numbers', tier: 3, prompt: 'How many chapters are in the whole Bible?', answer: '1,189', distractors: ['929', '1,050', '1,260'], explain: '929 in the Old Testament plus 260 in the New Testament.' },
+  // 'a-count-chapters' ("How many chapters are in the whole Bible?" → 1,189)
+  // was removed alongside the per-book chapter counts in #8: same species of
+  // question, same topic. The questions below survive because chapters are
+  // only incidental to them — the answer is a book or a chapter's *name*
+  // ("Psalm 119"), which is survey knowledge, not a tally.
   { id: 'a-longest-chapter', kind: 'type', topic: 'numbers', tier: 2, prompt: 'What is the longest chapter in the Bible?', answer: 'Psalm 119', accepts: ['psalms 119', '119', 'ps 119'], explain: '176 verses, an acrostic where each stanza begins with a successive Hebrew letter.' },
   { id: 'a-shortest-chapter', kind: 'type', topic: 'numbers', tier: 3, prompt: 'What is the shortest chapter in the Bible?', answer: 'Psalm 117', accepts: ['psalms 117', '117', 'ps 117'], explain: 'Just two verses.' },
   { id: 'a-longest-book', kind: 'mcq', topic: 'numbers', tier: 2, prompt: 'Which book has the most chapters?', answer: 'Psalms', distractors: ['Isaiah', 'Genesis', 'Jeremiah'], explain: 'Psalms has 150; Isaiah is next at 66.' },

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -8,7 +8,6 @@ import { buildEssentialItems } from './generate-essentials';
 import { pickDistractors, seededShuffle } from './rng';
 
 const bookNames = BOOKS.map((b) => b.name);
-const chapterCounts = [...new Set(BOOKS.map((b) => String(b.chapters)))];
 
 /** Distractors drawn from the same division are hard but fair. */
 function siblingNames(bookId: string): string[] {
@@ -21,14 +20,10 @@ function buildBookItems(): Item[] {
   const items: Item[] = [];
 
   for (const b of BOOKS) {
-    // --- Chapter count. Distractors are drawn from numerically nearby counts;
-    // offering 50 against 3, 5, and 7 tests nothing.
-    items.push({
-      id: `gen-chapters-${b.id}`, kind: 'mcq', topic: 'numbers', tier: 3, book: b.id,
-      prompt: `How many chapters are in ${b.name}?`,
-      answer: String(b.chapters),
-      distractors: pickDistractors(nearbyCounts(b.chapters), String(b.chapters), 3, `ch-${b.id}`),
-    });
+    // Per-book chapter counts used to live here. They were rote trivia — 66
+    // questions whose answer is a number you can read off a contents page —
+    // and they crowded the Numbers & Counts topic with the one kind of recall
+    // that teaches nothing about the book. Removed in #8.
 
     // --- Summary → book
     items.push({
@@ -394,13 +389,6 @@ for (const b of BOOKS) {
     const key = eventKey(ev);
     if (!eventOwner.has(key)) eventOwner.set(key, b.id);
   }
-}
-
-/** Chapter counts closest to `n`, so the wrong options are actually tempting. */
-function nearbyCounts(n: number): string[] {
-  return [...chapterCounts]
-    .sort((a, b) => Math.abs(Number(a) - n) - Math.abs(Number(b) - n))
-    .slice(0, 9);
 }
 
 function slug(s: string): string {

--- a/tests/e2e/content-contract.spec.ts
+++ b/tests/e2e/content-contract.spec.ts
@@ -12,13 +12,14 @@ import { ITEM, ORDER_SEQUENCE } from './harness';
 import { allItems, ITEMS_BY_ID } from '../../src/lib/generate';
 
 test.describe('content contract', () => {
-  test('the multiple-choice fixture is still a 4-option question with answer 50', () => {
+  test('the multiple-choice fixture is still a 4-option question answered by Exodus', () => {
     const item = ITEMS_BY_ID.get(ITEM.mcq);
     expect(item, `${ITEM.mcq} has left the item bank`).toBeDefined();
     expect(item!.kind).toBe('mcq');
-    expect(item!.prompt).toBe('How many chapters are in Genesis?');
-    expect(item!.answer).toBe('50');
-    expect(item!.distractors).toContain('36');
+    expect(item!.prompt).toBe('Which book immediately follows Genesis?');
+    expect(item!.answer).toBe('Exodus');
+    // The specs click this one to register a deliberate miss.
+    expect(item!.distractors).toContain('Deuteronomy');
     expect(item!.distractors).toHaveLength(3);
   });
 

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -22,8 +22,15 @@ export const OUTSIDER = 'someone@gmail.com';
  * `content-contract.spec.ts`, which fails loudly if the bank stops producing them.
  */
 export const ITEM = {
-  /** "How many chapters are in Genesis?" → 50 */
-  mcq: 'gen-chapters-genesis',
+  /**
+   * "Which book immediately follows Genesis?" → Exodus.
+   *
+   * Deliberately a `book-order` item rather than a summary or a chapter fact:
+   * the canon's sequence is the one thing no content issue is going to
+   * rewrite. The previous fixture here was `gen-chapters-genesis`, which #8
+   * deleted outright.
+   */
+  mcq: 'gen-position-genesis',
   /** "How many books are in the Bible?" → 66, accepts "sixty-six" */
   type: 'a-count-total',
   /** "Put these events from Genesis 1–4 in the order they occur." */

--- a/tests/e2e/progress.spec.ts
+++ b/tests/e2e/progress.spec.ts
@@ -48,8 +48,8 @@ test.describe('progress and settings', () => {
 
     await expect(page.getByRole('heading', { name: /Stuck items/ })).toBeVisible();
     const stuckRow = page.locator('h2:has-text("Stuck items") ~ * table.data tbody tr');
-    await expect(stuckRow).toContainText('How many chapters are in Genesis?');
-    await expect(stuckRow).toContainText('50');
+    await expect(stuckRow).toContainText('Which book immediately follows Genesis?');
+    await expect(stuckRow).toContainText('Exodus');
   });
 
   test('a clean history shows no stuck items at all', async ({ page }) => {

--- a/tests/e2e/question-kinds.spec.ts
+++ b/tests/e2e/question-kinds.spec.ts
@@ -14,14 +14,23 @@ async function reviewOne(page: Page, id: string) {
 /** Drag-free sort: walk each entry up until the list matches `want`. */
 async function arrangeInto(page: Page, want: string[]) {
   const rows = page.locator('.order-item');
+  const labels = () => rows.locator('span:not(.num):not(.moves)');
   for (let target = 0; target < want.length; target++) {
     for (;;) {
-      const labels = await rows.locator('span:not(.num):not(.moves)').allInnerTexts();
-      const at = labels.indexOf(want[target]);
+      const at = (await labels().allInnerTexts()).indexOf(want[target]);
       if (at <= target) break;
       await rows.nth(at).getByRole('button', { name: 'Move up' }).click();
+      // Wait for the row to actually land in its new slot before re-reading.
+      // Without this the next allInnerTexts() can observe the pre-click DOM,
+      // compute a stale index, and walk some other row up the list — which
+      // shows up as an arrangement that is only partly sorted.
+      await expect(labels().nth(at - 1)).toHaveText(want[target]);
     }
   }
+  // Fail in the helper, not three assertions later. Callers that submit an
+  // arrangement without checking it first would otherwise report a confusing
+  // count mismatch instead of "the list never got sorted".
+  await expect(labels()).toHaveText(want);
 }
 
 async function currentOrder(page: Page): Promise<string[]> {
@@ -32,9 +41,9 @@ test.describe('multiple choice', () => {
   test('a right answer reveals the grade buttons and records the card', async ({ page }) => {
     await reviewOne(page, ITEM.mcq);
 
-    await expect(page.getByText('How many chapters are in Genesis?')).toBeVisible();
+    await expect(page.getByText('Which book immediately follows Genesis?')).toBeVisible();
     await expect(page.locator('.choice')).toHaveCount(4);
-    await choice(page, '50').click();
+    await choice(page, 'Exodus').click();
 
     await expect(page.locator('.feedback.correct')).toContainText('Correct');
     await expect(page.getByRole('button', { name: /^Good/ })).toBeVisible();
@@ -48,12 +57,12 @@ test.describe('multiple choice', () => {
   test('a wrong answer shows the right one and marks both options', async ({ page }) => {
     await reviewOne(page, ITEM.mcq);
 
-    await choice(page, '36').click();
+    await choice(page, 'Deuteronomy').click();
 
     await expect(page.locator('.feedback.wrong')).toContainText('Not quite');
-    await expect(page.locator('.feedback')).toContainText('Answer: 50');
-    await expect(page.locator('.choice.correct')).toHaveText(/50/);
-    await expect(page.locator('.choice.wrong')).toHaveText(/36/);
+    await expect(page.locator('.feedback')).toContainText('Answer: Exodus');
+    await expect(page.locator('.choice.correct')).toHaveText(/Exodus/);
+    await expect(page.locator('.choice.wrong')).toHaveText(/Deuteronomy/);
     // A miss offers no self-grading — it goes back in the queue as "again".
     await expect(page.getByRole('button', { name: /^Good/ })).toBeHidden();
     await expect(page.getByRole('button', { name: /^Continue/ })).toBeVisible();
@@ -62,7 +71,7 @@ test.describe('multiple choice', () => {
   test('every option locks once an answer is in', async ({ page }) => {
     await reviewOne(page, ITEM.mcq);
 
-    await choice(page, '36').click();
+    await choice(page, 'Deuteronomy').click();
 
     for (const choice of await page.locator('.choice').all()) {
       await expect(choice).toBeDisabled();
@@ -74,7 +83,7 @@ test.describe('multiple choice', () => {
 
     // Options are reshuffled per item, so find where the right answer landed.
     const labels = await page.locator('.choice span:not(.key)').allInnerTexts();
-    const slot = labels.indexOf('50');
+    const slot = labels.indexOf('Exodus');
     expect(slot, 'the correct option should be on screen').toBeGreaterThanOrEqual(0);
 
     await page.keyboard.press(String(slot + 1));

--- a/tests/e2e/quiz.spec.ts
+++ b/tests/e2e/quiz.spec.ts
@@ -60,7 +60,7 @@ test.describe('mixed quiz', () => {
     await page.getByRole('button', { name: 'Start quiz' }).click();
 
     await expect(page.getByRole('progressbar', { name: 'Progress: question 1 of 1' })).toBeVisible();
-    await page.locator('.choice').filter({ has: page.getByText('36', { exact: true }) }).click();
+    await page.locator('.choice').filter({ has: page.getByText('Deuteronomy', { exact: true }) }).click();
     await page.getByRole('button', { name: /^Continue/ }).click();
 
     await expect(cardTitle(page, 'Quiz complete')).toBeVisible();
@@ -69,8 +69,8 @@ test.describe('mixed quiz', () => {
 
     const missedRow = page.locator('table.data tbody tr');
     await expect(missedRow).toHaveCount(1);
-    await expect(missedRow).toContainText('How many chapters are in Genesis?');
-    await expect(missedRow).toContainText('50');
+    await expect(missedRow).toContainText('Which book immediately follows Genesis?');
+    await expect(missedRow).toContainText('Exodus');
   });
 
   test('a clean run reports full marks and lists nothing missed', async ({ page }) => {
@@ -78,7 +78,7 @@ test.describe('mixed quiz', () => {
 
     await scope(page, 'Starred').click();
     await page.getByRole('button', { name: 'Start quiz' }).click();
-    await page.locator('.choice').filter({ has: page.getByText('50', { exact: true }) }).click();
+    await page.locator('.choice').filter({ has: page.getByText('Exodus', { exact: true }) }).click();
     await page.getByRole('button', { name: /^Good/ }).click();
 
     await expect(cardTitle(page, 'Quiz complete')).toBeVisible();
@@ -91,7 +91,7 @@ test.describe('mixed quiz', () => {
     await openAs(page, { store: { starred: [ITEM.mcq] } }, 'quiz');
     await scope(page, 'Starred').click();
     await page.getByRole('button', { name: 'Start quiz' }).click();
-    await page.locator('.choice').filter({ has: page.getByText('50', { exact: true }) }).click();
+    await page.locator('.choice').filter({ has: page.getByText('Exodus', { exact: true }) }).click();
     await page.getByRole('button', { name: /^Good/ }).click();
 
     await page.getByRole('button', { name: 'Retake' }).click();
@@ -117,7 +117,7 @@ test.describe('mixed quiz', () => {
 
     await expect(poolCount(page)).toContainText(/^1 question match/);
     await page.getByRole('button', { name: 'Start quiz' }).click();
-    await expect(page.getByText('How many chapters are in Genesis?')).toBeVisible();
+    await expect(page.getByText('Which book immediately follows Genesis?')).toBeVisible();
   });
 
   test('quiz answers feed the same review schedule', async ({ page }) => {
@@ -125,7 +125,7 @@ test.describe('mixed quiz', () => {
 
     await scope(page, 'Starred').click();
     await page.getByRole('button', { name: 'Start quiz' }).click();
-    await page.locator('.choice').filter({ has: page.getByText('50', { exact: true }) }).click();
+    await page.locator('.choice').filter({ has: page.getByText('Exodus', { exact: true }) }).click();
     await page.getByRole('button', { name: /^Good/ }).click();
     await expect(cardTitle(page, 'Quiz complete')).toBeVisible();
 

--- a/tests/e2e/review.spec.ts
+++ b/tests/e2e/review.spec.ts
@@ -30,7 +30,7 @@ test.describe('daily review', () => {
     await expect(page.getByRole('progressbar', { name: '0 of 1 answered' })).toBeVisible();
     await expect(page.getByText('1 / 1')).toBeVisible();
 
-    await answerMcq(page, '50');
+    await answerMcq(page, 'Exodus');
     await page.getByRole('button', { name: /^Good/ }).click();
 
     await expect(page.getByRole('heading', { name: 'Session complete' })).toBeVisible();
@@ -57,11 +57,11 @@ test.describe('daily review', () => {
     await openAs(page, { store: soloQueue(ITEM.mcq) }, 'review');
     await start(page);
 
-    await answerMcq(page, '36');
+    await answerMcq(page, 'Deuteronomy');
     await page.getByRole('button', { name: /^Continue/ }).click();
 
     // The card is back — it should be asked afresh, not shown already answered.
-    await expect(page.getByText('How many chapters are in Genesis?')).toBeVisible();
+    await expect(page.getByText('Which book immediately follows Genesis?')).toBeVisible();
     await expect(page.locator('.feedback')).toHaveCount(0);
     await expect(page.locator('.choice').first()).toBeEnabled();
   });
@@ -72,9 +72,9 @@ test.describe('daily review', () => {
 
     // Miss it three times; the third must not extend the session again.
     for (let attempt = 1; attempt <= 3; attempt++) {
-      await expect(page.getByText('How many chapters are in Genesis?')).toBeVisible();
+      await expect(page.getByText('Which book immediately follows Genesis?')).toBeVisible();
       // Tolerates the requeue bug above: only answer if the card is still open.
-      if (await page.locator('.feedback').count() === 0) await answerMcq(page, '36');
+      if (await page.locator('.feedback').count() === 0) await answerMcq(page, 'Deuteronomy');
       await page.getByRole('button', { name: /^Continue/ }).click();
     }
 
@@ -111,7 +111,7 @@ test.describe('daily review', () => {
   test('another session can be started from the summary', async ({ page }) => {
     await openAs(page, { store: soloQueue(ITEM.mcq) }, 'review');
     await start(page);
-    await answerMcq(page, '50');
+    await answerMcq(page, 'Exodus');
     await page.getByRole('button', { name: /^Good/ }).click();
 
     await expect(page.getByRole('heading', { name: 'Session complete' })).toBeVisible();
@@ -131,7 +131,7 @@ test.describe('daily review', () => {
     }, 'review');
     await start(page);
 
-    await answerMcq(page, '50');
+    await answerMcq(page, 'Exodus');
     await page.getByRole('button', { name: /^Easy/ }).click();
 
     const store = await readStore(page);


### PR DESCRIPTION
Closes #8.

## What went

- **`gen-chapters-*`** — 66 per-book "How many chapters are in X?" items. Rote trivia: the answer is a number you read off a contents page.
- **`a-count-chapters`** — "How many chapters are in the whole Bible?" → 1,189.
- `chapterCounts` and `nearbyCounts`, which existed only to build distractors for the deleted question.

**Flagging the second one explicitly**, since the issue title names the category rather than the items. It is the same species of question in the same topic, and leaving it would have left the issue visibly half-fixed — you would still meet a chapter-count question under Numbers & Counts. It is a one-line revert in `src/data/extras.ts` if you disagree.

## What stayed

Numbers & Counts keeps its other **256** items. The neighbours survive because chapters are only *incidental* to them and the answer is a name rather than a tally:

| Kept | Answer |
|---|---|
| What is the longest chapter in the Bible? | Psalm 119 |
| What is the shortest chapter in the Bible? | Psalm 117 |
| Which book has the most chapters? | Psalms |

Bank is **6,514** items, and `npm run validate` confirms every book still clears the 20-question floor.

## Test fixtures

This deletes `gen-chapters-genesis`, which the suite used as its multiple-choice fixture — `content-contract.spec.ts` caught it exactly as designed. Re-pointed at **`gen-position-genesis`** ("Which book immediately follows Genesis?" → Exodus).

Chosen deliberately over a summary item: `gen-summary-to-book-*` and `gen-theme-*` are both topic `summaries`, and **#9 kills every non-prophet one** — that fixture would break again on the next issue. `book-order` is the one topic none of the nine remaining issues touches. 25 call sites updated across 6 files. No spec deleted or skipped.

## One unrelated fix, bundled

`arrangeInto` in `question-kinds.spec.ts` had a genuine race — it re-read the list immediately after clicking "Move up", so under load it computed an index from the pre-click DOM and walked the wrong row. It now waits for each row to land, and asserts the finished arrangement, because one caller submitted an arrangement without ever checking it and the race surfaced three assertions later as a confusing count mismatch.

It is in this PR rather than its own because it was blocking a trustworthy green run. Happy to split it out if you would rather.

## Verified

- `npx tsc -b` clean
- `npm run validate` — all checks pass
- `npx playwright test --workers=2` — **82 passed**, exit 0

(At default worker count this box flakes on timeouts — load average 14 on 8 cores with two agent sessions running. Different random test each run, all green in isolation. Environmental, not code; CI runs 2 workers with 2 retries.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)