### PR TITLE
Generate book-summary questions for the prophets only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Changed
+
+- **Book-summary questions are now prophets-only** ([#9]). The five per-book
+  summary generators — "Which book is this?", "What is the central theme of X?",
+  "Why was X written?", "Who was X written to?", and the distinctive-trait
+  question — now fire only for the seventeen Major and Minor Prophets. They are
+  the one stretch of canon where a summary is the thing worth knowing:
+  overlapping vocabulary and no narrative spine, so "which book is this?" is a
+  real question rather than a recital. Bank drops from 6,514 to 6,269 items;
+  the Book Summaries topic keeps 194 items (85 across the prophets, plus 109
+  must-know-list and trivia questions that are not about a book's summary at
+  all). Every book still clears the 20-question floor — the leanest, 2 John,
+  sits at 23.
+
 ### Removed
 
 - **Chapter-count questions** ([#8]). The 66 per-book "How many chapters are in
@@ -41,3 +55,5 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [#7]: https://github.com/godwinlaw/scripture-mastery/issues/7
 
 [#8]: https://github.com/godwinlaw/scripture-mastery/issues/8
+
+[#9]: https://github.com/godwinlaw/scripture-mastery/issues/9

--- a/src/data/books.ts
+++ b/src/data/books.ts
@@ -1149,5 +1149,17 @@ export const BOOKS_BY_ID: Record<string, Book> = Object.fromEntries(
 export const OT = BOOKS.filter((b) => b.testament === 'OT');
 export const NT = BOOKS.filter((b) => b.testament === 'NT');
 
+/**
+ * The prophets are the one stretch of the canon where a book's summary is the
+ * thing worth knowing: seventeen books with overlapping vocabulary, and no
+ * narrative spine to hang them on, so "which book is this?" is a real question
+ * rather than a recital. Everywhere else the summary questions were noise, and
+ * #9 stopped generating them.
+ */
+export function isPropheticBook(bookId: string): boolean {
+  const division = BOOKS_BY_ID[bookId]?.division;
+  return division === 'Major Prophets' || division === 'Minor Prophets';
+}
+
 /** Chapter totals — useful as a self-check that the data stayed intact. */
 export const TOTAL_CHAPTERS = BOOKS.reduce((n, b) => n + b.chapters, 0); // 1189

--- a/src/lib/generate-detail.ts
+++ b/src/lib/generate-detail.ts
@@ -1,4 +1,4 @@
-import { BOOKS } from '../data/books';
+import { BOOKS, isPropheticBook } from '../data/books';
 import { DETAILS, type BookDetail, type DetailEvent } from '../data/details';
 import type { Item } from '../data/types';
 import { pickDistractors, seededShuffle } from './rng';
@@ -260,21 +260,25 @@ function frameItems(d: BookDetail): Item[] {
   const items: Item[] = [];
   const name = bookName.get(d.book)!;
 
-  items.push({
-    id: `det-purpose-${d.book}`, kind: 'mcq', topic: 'summaries', tier: 2, book: d.book,
-    prompt: `Why was ${name} written?`,
-    answer: d.purpose,
-    distractors: pickDistractors(allPurposes, d.purpose, 3, `pur-${d.book}`),
-    explain: `Audience: ${d.audience}.`,
-  });
+  // Purpose and audience summarise the book rather than teach its contents, so
+  // they follow the same prophets-only rule as the other summary questions (#9).
+  if (isPropheticBook(d.book)) {
+    items.push({
+      id: `det-purpose-${d.book}`, kind: 'mcq', topic: 'summaries', tier: 2, book: d.book,
+      prompt: `Why was ${name} written?`,
+      answer: d.purpose,
+      distractors: pickDistractors(allPurposes, d.purpose, 3, `pur-${d.book}`),
+      explain: `Audience: ${d.audience}.`,
+    });
 
-  items.push({
-    id: `det-audience-${d.book}`, kind: 'mcq', topic: 'summaries', tier: 3, book: d.book,
-    prompt: `Who was ${name} written to?`,
-    answer: d.audience,
-    distractors: pickDistractors(allAudiences, d.audience, 3, `aud-${d.book}`),
-    explain: d.purpose,
-  });
+    items.push({
+      id: `det-audience-${d.book}`, kind: 'mcq', topic: 'summaries', tier: 3, book: d.book,
+      prompt: `Who was ${name} written to?`,
+      answer: d.audience,
+      distractors: pickDistractors(allAudiences, d.audience, 3, `aud-${d.book}`),
+      explain: d.purpose,
+    });
+  }
 
   items.push({
     id: `det-written-${d.book}`, kind: 'mcq', topic: 'timeline', tier: 3, book: d.book,
@@ -292,7 +296,7 @@ function frameItems(d: BookDetail): Item[] {
     explain: d.purpose,
   });
 
-  if (d.distinctive) {
+  if (d.distinctive && isPropheticBook(d.book)) {
     items.push({
       id: `det-distinctive-${d.book}`, kind: 'mcq', topic: 'summaries', tier: 3, book: d.book,
       prompt: `Which book is this true of? "${d.distinctive}"`,

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -1,4 +1,4 @@
-import { BOOKS } from '../data/books';
+import { BOOKS, isPropheticBook } from '../data/books';
 import { PEOPLE, PLACES } from '../data/people';
 import { ERAS, EVENTS } from '../data/timeline';
 import { AUTHORED, LIST_DECOYS, LISTS } from '../data/extras';
@@ -25,23 +25,25 @@ function buildBookItems(): Item[] {
     // and they crowded the Numbers & Counts topic with the one kind of recall
     // that teaches nothing about the book. Removed in #8.
 
-    // --- Summary → book
-    items.push({
-      id: `gen-summary-to-book-${b.id}`, kind: 'mcq', topic: 'summaries', tier: 1, book: b.id,
-      prompt: `Which book is this? "${b.oneLine}"`,
-      answer: b.name,
-      distractors: pickDistractors(siblingNames(b.id), b.name, 3, `s2b-${b.id}`),
-      explain: b.hook,
-    });
+    // --- Summary → book, and book → theme. Prophets only: see
+    // isPropheticBook() for why the rest of the canon stopped asking (#9).
+    if (isPropheticBook(b.id)) {
+      items.push({
+        id: `gen-summary-to-book-${b.id}`, kind: 'mcq', topic: 'summaries', tier: 1, book: b.id,
+        prompt: `Which book is this? "${b.oneLine}"`,
+        answer: b.name,
+        distractors: pickDistractors(siblingNames(b.id), b.name, 3, `s2b-${b.id}`),
+        explain: b.hook,
+      });
 
-    // --- Book → theme
-    items.push({
-      id: `gen-theme-${b.id}`, kind: 'mcq', topic: 'summaries', tier: 2, book: b.id,
-      prompt: `What is the central theme of ${b.name}?`,
-      answer: b.theme,
-      distractors: pickDistractors(BOOKS.map((x) => x.theme), b.theme, 3, `theme-${b.id}`),
-      explain: b.oneLine,
-    });
+      items.push({
+        id: `gen-theme-${b.id}`, kind: 'mcq', topic: 'summaries', tier: 2, book: b.id,
+        prompt: `What is the central theme of ${b.name}?`,
+        answer: b.theme,
+        distractors: pickDistractors(BOOKS.map((x) => x.theme), b.theme, 3, `theme-${b.id}`),
+        explain: b.oneLine,
+      });
+    }
 
     // --- Position in canon
     items.push({


### PR DESCRIPTION
Closes #9.

The five per-book summary generators now fire only for the seventeen Major and Minor Prophets:

| Generator | Question |
|---|---|
| `gen-summary-to-book-*` | Which book is this? "…" |
| `gen-theme-*` | What is the central theme of X? |
| `det-purpose-*` | Why was X written? |
| `det-audience-*` | Who was X written to? |
| `det-distinctive-*` | Which book is this true of? "…" |

## Why the prophets are the exception

They are the one stretch of canon where a book's summary is the thing worth knowing — seventeen books with overlapping vocabulary and no narrative spine to hang them on, so "which book is this?" is a real question. Everywhere else you already tell Exodus from Judges by its events and people, and the summary card was asking you to match marketing copy to a title.

## Scope call worth reviewing

I included `det-purpose`, `det-audience` and `det-distinctive`, not just the two obvious summary generators. All five carry `topic: "summaries"` and all five summarise a book rather than teach its contents; leaving three of them firing for all 66 books would have left the Book Summaries topic looking largely intact and the issue visibly half-done. Same reading I applied in #8. Easy to narrow if you meant only the first two.

## What deliberately stayed

The must-know-list questions (`gen-list-*`) and the Esther trivia (`a-no-god-named`) also carry `topic: "summaries"`, but they are not about a book's summary — they are untouched.

The predicate lives in `books.ts` next to the data it reads, because both generators need it and neither owns it.

## Numbers

- Bank **6,514 → 6,269**
- Book Summaries topic keeps **194** items: 85 across the prophets, 109 list/trivia
- **Zero** non-prophet books retain a summary question (verified directly, not inferred)
- Every book still clears the 20-question floor; leanest is 2 John at **23**

## Verified

- `npx tsc -b` clean
- `npm run validate` — all checks pass, including the per-book floor
- `npx playwright test --workers=2` — **82 passed**, exit 0. No fixture broke: `content-contract.spec.ts` passed untouched, which is the payoff from re-pointing the mcq fixture at a `book-order` item in #20 rather than a summary one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)