### PR TITLE
Draw Chapter Content options from nearby books only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Chapter Content options now come from nearby books** ([#10]). "What happens
+  in Leviticus 10?" used to draw its wrong options from anywhere in the canon,
+  so it could offer a verse from Colossians — not a hard question, just a
+  different subject. All five Chapter Content generators now build their pool
+  from the answer's own division, widening one division at a time only when the
+  tighter pool cannot fill four options, and **never crossing the Old/New
+  Testament seam**. Verified against the generated bank: of 3,193 attributable
+  distractors across 1,528 questions, zero cross the Testament boundary and
+  zero fall outside the neighbourhood, with every question still offering four
+  options. One-book divisions widen as intended — Acts reaches into the Pauline
+  Epistles, Revelation into the General Epistles.
+
 - **Book-summary questions are now prophets-only** ([#9]). The five per-book
   summary generators — "Which book is this?", "What is the central theme of X?",
   "Why was X written?", "Who was X written to?", and the distinctive-trait
@@ -57,3 +69,5 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [#8]: https://github.com/godwinlaw/scripture-mastery/issues/8
 
 [#9]: https://github.com/godwinlaw/scripture-mastery/issues/9
+
+[#10]: https://github.com/godwinlaw/scripture-mastery/issues/10

--- a/src/data/books.ts
+++ b/src/data/books.ts
@@ -1,4 +1,4 @@
-import type { Book } from './types';
+import type { Book, Division, Testament } from './types';
 
 /**
  * All 66 books, structured so questions can be generated rather than hand-written.
@@ -1148,6 +1148,64 @@ export const BOOKS_BY_ID: Record<string, Book> = Object.fromEntries(
 
 export const OT = BOOKS.filter((b) => b.testament === 'OT');
 export const NT = BOOKS.filter((b) => b.testament === 'NT');
+
+/**
+ * The divisions in canonical order, kept as two lists so that widening a
+ * distractor pool can never step across the Testament seam. Offering Colossians
+ * against "What happens in Leviticus 10?" is not a hard question, it is a
+ * different subject — the wrong options have to be plausible neighbours to test
+ * anything (#10, #12).
+ */
+const DIVISIONS_BY_TESTAMENT: Record<Testament, readonly Division[]> = {
+  OT: ['Law', 'History', 'Wisdom', 'Major Prophets', 'Minor Prophets'],
+  NT: ['Gospels', 'Acts', 'Pauline Epistles', 'General Epistles', 'Apocalyptic'],
+};
+
+/**
+ * Books near `bookId`: its own division at `rings = 0`, then one division
+ * further out in each direction per ring, never leaving the Testament.
+ *
+ * Callers widen a ring at a time only when the tighter pool cannot fill the
+ * options, so a question drawn from a one-book division (Acts, Revelation)
+ * still gets four choices without silently reaching across the canon.
+ */
+export function booksNear(bookId: string, rings = 0): Book[] {
+  const book = BOOKS_BY_ID[bookId];
+  if (!book) return [];
+  const order = DIVISIONS_BY_TESTAMENT[book.testament];
+  const at = order.indexOf(book.division);
+  if (at === -1) return BOOKS.filter((b) => b.testament === book.testament);
+
+  const lo = Math.max(0, at - rings);
+  const hi = Math.min(order.length - 1, at + rings);
+  const wanted = new Set(order.slice(lo, hi + 1));
+  return BOOKS.filter((b) => b.testament === book.testament && wanted.has(b.division));
+}
+
+/**
+ * The tightest pool around `bookId` that can still supply `n` distinct options
+ * other than `answer`, widening a division at a time and stopping at the
+ * Testament boundary.
+ *
+ * `extract` pulls the candidate strings out of each book, so the same widening
+ * rule serves chapter summaries, references, and book names alike.
+ */
+export function nearbyPool(
+  bookId: string,
+  extract: (b: Book) => string[],
+  answer: string,
+  n = 3,
+): string[] {
+  const widest = DIVISIONS_BY_TESTAMENT[BOOKS_BY_ID[bookId]?.testament ?? 'OT'].length;
+  let pool: string[] = [];
+  for (let rings = 0; rings <= widest; rings++) {
+    pool = [...new Set(booksNear(bookId, rings).flatMap(extract))].filter((s) => s !== answer);
+    if (pool.length >= n) return pool;
+  }
+  // Whole Testament still too thin: return what there is rather than reaching
+  // across the seam. pickDistractors will simply yield fewer options.
+  return pool;
+}
 
 /**
  * The prophets are the one stretch of the canon where a book's summary is the

--- a/src/lib/generate-detail.ts
+++ b/src/lib/generate-detail.ts
@@ -1,10 +1,13 @@
-import { BOOKS, isPropheticBook } from '../data/books';
+import { BOOKS, isPropheticBook, nearbyPool } from '../data/books';
 import { DETAILS, type BookDetail, type DetailEvent } from '../data/details';
 import type { Item } from '../data/types';
 import { pickDistractors, seededShuffle } from './rng';
 
 const bookName = new Map(BOOKS.map((b) => [b.id, b.name]));
 const bookAbbr = new Map(BOOKS.map((b) => [b.id, b.abbr]));
+
+/** Lets a Book-keyed pool walk reach that book's detail entry (#10). */
+const detailByBook = new Map(DETAILS.map((d) => [d.book, d]));
 
 /** Every "what" across every book — the pool for chapter-content distractors. */
 const allEventWhats = DETAILS.flatMap((d) => d.events.map((e) => e.what));
@@ -93,7 +96,11 @@ function eventItems(d: BookDetail): Item[] {
       prompt: `Where does this happen? "${e.what}"`,
       answer: `${abbr} ${e.ref}`,
       distractors: pickDistractors(
-        DETAILS.flatMap((x) => x.events.map((y) => `${bookAbbr.get(x.book)} ${y.ref}`)),
+        nearbyPool(
+          d.book,
+          (x) => (detailByBook.get(x.id)?.events ?? []).map((y) => `${bookAbbr.get(x.id)} ${y.ref}`),
+          `${abbr} ${e.ref}`,
+        ),
         `${abbr} ${e.ref}`, 3, `evr-${key}`,
       ),
       explain: `${e.name} — ${ref(d, e.ref)}.`,
@@ -324,7 +331,8 @@ function frameItems(d: BookDetail): Item[] {
       prompt: `Where is this from? "${v.text}"`,
       answer: v.ref,
       distractors: pickDistractors(
-        DETAILS.flatMap((x) => (x.verses ?? []).map((y) => y.ref)), v.ref, 3, `vs-${d.book}-${i}`,
+        nearbyPool(d.book, (x) => (detailByBook.get(x.id)?.verses ?? []).map((y) => y.ref), v.ref),
+        v.ref, 3, `vs-${d.book}-${i}`,
       ),
       explain: `${name} — ${d.purpose}`,
     });

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -1,4 +1,4 @@
-import { BOOKS, isPropheticBook } from '../data/books';
+import { BOOKS, isPropheticBook, nearbyPool } from '../data/books';
 import { PEOPLE, PLACES } from '../data/people';
 import { ERAS, EVENTS } from '../data/timeline';
 import { AUTHORED, LIST_DECOYS, LISTS } from '../data/extras';
@@ -71,7 +71,7 @@ function buildBookItems(): Item[] {
         prompt: `What happens in ${b.name} ${kc.ch}?`,
         answer: kc.what,
         distractors: pickDistractors(
-          BOOKS.flatMap((x) => x.keyChapters.map((k) => k.what)),
+          nearbyPool(b.id, (x) => x.keyChapters.map((k) => k.what), kc.what),
           kc.what, 3, `chwhat-${b.id}-${kc.ch}`,
         ),
       });
@@ -80,7 +80,7 @@ function buildBookItems(): Item[] {
         prompt: `Where does this happen? "${kc.what}"`,
         answer: `${b.name} ${kc.ch}`,
         distractors: pickDistractors(
-          BOOKS.flatMap((x) => x.keyChapters.map((k) => `${x.name} ${k.ch}`)),
+          nearbyPool(b.id, (x) => x.keyChapters.map((k) => `${x.name} ${k.ch}`), `${b.name} ${kc.ch}`),
           `${b.name} ${kc.ch}`, 3, `loc-${b.id}-${kc.ch}`,
         ),
       });
@@ -110,7 +110,10 @@ function buildBookItems(): Item[] {
         id: `gen-verse-${b.id}`, kind: 'mcq', topic: 'chapters', tier: 3, book: b.id,
         prompt: `Which book is this from? "${b.keyVerse.text}"`,
         answer: b.name,
-        distractors: pickDistractors(bookNames, b.name, 3, `kv-${b.id}`),
+        distractors: pickDistractors(
+          nearbyPool(b.id, (x) => [x.name], b.name),
+          b.name, 3, `kv-${b.id}`,
+        ),
         explain: `${b.keyVerse.ref} (ESV)`,
       });
     }


### PR DESCRIPTION
Closes #10.

## Before

> **What happens in Leviticus 10?**
> ✓ Nadab and Abihu offer unauthorized fire and die
> ✗ …anything from anywhere in the canon, including Colossians

Not a hard question — a different subject. The wrong options have to be plausible neighbours to test anything.

## After

> **What happens in Leviticus 10?**
> ✓ Nadab and Abihu offer unauthorized fire and die
> ✗ The Ten Commandments restated for the new generation *(Deuteronomy)*
> ✗ The five offerings: burnt, grain, peace, sin, guilt *(Leviticus)*
> ✗ The Flood and God’s covenant with Noah *(Genesis)*

All five books of Moses, exactly as the issue asked.

## How

Two new helpers in `books.ts`. Divisions are held as **two ordered lists, one per Testament**, so widening can step to an adjacent division but can never cross the seam:

- `booksNear(bookId, rings)` — own division at ring 0, one division further each way per ring
- `nearbyPool(bookId, extract, answer)` — the *tightest* pool that can still fill the options, widening a ring at a time

`nearbyPool` takes an `extract` callback rather than a fixed field. That is what lets one widening rule serve chapter summaries, references, and book names alike — and what will let **#12 reuse it for Events** rather than growing a second copy.

Rewires all five Chapter Content generators: `gen-chapter`, `gen-locate`, `gen-verse`, `det-ev-ref`, `det-verse`.

## One-book divisions still fill four options

The widening is what keeps Acts and Revelation answerable:

> Which book is this from? *"You will be my witnesses in Jerusalem…"*
> ✓ Acts ✗ 2 Corinthians / 1 Corinthians / 2 Timothy

> Which book is this from? *"He will wipe away every tear…"*
> ✓ Revelation ✗ 1 John / 1 Peter / Jude

Adjacent divisions, same Testament.

## Verified against the bank, not by inspection

I wrote a throwaway probe that attributes every distractor back to a book and checks the rule directly:

| Check | Result |
|---|---|
| Chapter Content mcq items | 1,528 |
| Attributable distractors checked | 3,193 |
| **Cross-Testament distractors** | **0** |
| Outside the neighbourhood | 0 |
| mcq items anywhere with <3 distractors | 0 |

One caveat worth recording: my first probe reported a single cross-Testament hit that turned out to be the probe’s own bug — it attributed *"**Gen**ealogy, virgin birth, wise men…"* to Genesis by prefix, when it is Matthew 1 and correctly in-division for Mark. Attribution now requires a chapter number after the book label. The zero above is from the corrected probe.

## Verified

- `npx tsc -b` clean
- `npm run validate` — all checks pass
- `npx playwright test --workers=2` — **82 passed**, exit 0. `content-contract.spec.ts` green untouched: its `distractors` assertions are on a `book-order` item, and this change touches only `chapters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)