### PR TITLE
Shuffle the daily review queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Daily review questions are shuffled** ([#11]). The queue was fully
+  deterministic, so the same cards arrived in the same order every day and you
+  could start recalling the sequence instead of the answer. `buildQueue` now
+  shuffles what it presents. Selection is deliberately left alone and still
+  runs first — sort by how overdue a card is, interleave the books, *then* cut
+  to the session limit — so a truncated session still takes the most urgent
+  cards and a spread of books. Only the order they are asked in is random.
+  Covered by a new `tests/e2e/queue.spec.ts`, which pins both halves: that the
+  order varies between sessions, and that a truncated session still keeps the
+  most overdue cards.
+
 - **Chapter Content options now come from nearby books** ([#10]). "What happens
   in Leviticus 10?" used to draw its wrong options from anywhere in the canon,
   so it could offer a verse from Colossians — not a hard question, just a
@@ -71,3 +82,5 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [#9]: https://github.com/godwinlaw/scripture-mastery/issues/9
 
 [#10]: https://github.com/godwinlaw/scripture-mastery/issues/10
+
+[#11]: https://github.com/godwinlaw/scripture-mastery/issues/11

--- a/src/lib/srs.ts
+++ b/src/lib/srs.ts
@@ -3,6 +3,7 @@
  * every card comes back at least once before the exam date. A card scheduled for
  * 60 days out is useless when the test is in 40.
  */
+import { shuffle } from './rng';
 
 export type Grade = 0 | 1 | 2 | 3; // again | hard | good | easy
 
@@ -117,7 +118,16 @@ export function buildQueue(
 
   due.sort((a, b) => cards[a].due - cards[b].due);
   const picked = [...due, ...fresh.slice(0, opts.newLimit)];
-  return interleave(picked).slice(0, opts.sessionLimit);
+  // Order matters twice here, for different reasons.
+  //
+  // Selecting: sort by how overdue a card is, interleave the books, and only
+  // then cut to the session limit — so a truncated session still takes the
+  // most urgent cards and a spread of books, not the first N of one.
+  //
+  // Presenting: shuffle what survived. The selection above is deterministic,
+  // so without this you meet the same cards in the same order every day and
+  // start recalling the sequence rather than the answer (#11).
+  return shuffle(interleave(picked).slice(0, opts.sessionLimit));
 }
 
 /** Spread same-prefix items apart so you are not answering six Genesis cards in a row. */

--- a/tests/e2e/queue.spec.ts
+++ b/tests/e2e/queue.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * buildQueue does two separable jobs, and #11 changed only the second.
+ *
+ * Selecting *which* cards a session holds must stay deterministic and
+ * priority-ordered — most overdue first, capped by the limits — because that
+ * is what makes a truncated session the right session. Presenting them is now
+ * shuffled, so you stop learning the sequence instead of the answers.
+ *
+ * These run in Node against the real scheduler, so a regression in either half
+ * says so directly rather than as a puzzling UI failure.
+ */
+import { expect, test } from '@playwright/test';
+import { buildQueue, type CardState } from '../../src/lib/srs';
+
+const DAY = 86_400_000;
+
+/** A card in rotation, `overdueDays` past its due date. */
+function seen(id: string, overdueDays: number): CardState {
+  return {
+    id,
+    ease: 2.5,
+    interval: 1,
+    reps: 2,
+    lapses: 0,
+    due: Date.now() - overdueDays * DAY,
+    lastSeen: Date.now() - (overdueDays + 1) * DAY,
+    recent: [2, 2],
+  };
+}
+
+function deck(n: number, from = 0): { ids: string[]; cards: Record<string, CardState> } {
+  const ids = Array.from({ length: n }, (_, i) => `card-${from + i}`);
+  const cards: Record<string, CardState> = {};
+  // Descending overdue-ness, so card-0 is the most urgent.
+  ids.forEach((id, i) => { cards[id] = seen(id, n - i); });
+  return { ids, cards };
+}
+
+const NO_NEW = { newLimit: 0, sessionLimit: 100 };
+
+test.describe('review queue', () => {
+  test('presentation order is shuffled between sessions', () => {
+    const { ids, cards } = deck(30);
+    const runs = Array.from({ length: 8 }, () => buildQueue(ids, cards, NO_NEW).join(','));
+
+    // With 30 cards the odds of two honest shuffles matching are 1/30!, so a
+    // single repeat across eight runs means the order is not being shuffled.
+    expect(new Set(runs).size, 'buildQueue returned the same order twice').toBe(runs.length);
+  });
+
+  test('shuffling does not lose, duplicate, or invent a card', () => {
+    const { ids, cards } = deck(30);
+    const q = buildQueue(ids, cards, NO_NEW);
+
+    expect(q).toHaveLength(ids.length);
+    expect(new Set(q).size).toBe(ids.length);
+    expect([...q].sort()).toEqual([...ids].sort());
+  });
+
+  test('a truncated session still takes the most overdue cards', () => {
+    // The selection half must survive the shuffle: cutting to 5 has to keep
+    // the five most urgent cards, whatever order they are then asked in.
+    const { ids, cards } = deck(20);
+    const q = buildQueue(ids, cards, { newLimit: 0, sessionLimit: 5 });
+
+    expect(q).toHaveLength(5);
+    expect([...q].sort()).toEqual(['card-0', 'card-1', 'card-2', 'card-3', 'card-4']);
+  });
+
+  test('new cards are still capped by the new-card limit', () => {
+    const { ids: dueIds, cards } = deck(3);
+    const freshIds = Array.from({ length: 10 }, (_, i) => `fresh-${i}`);
+
+    const q = buildQueue([...dueIds, ...freshIds], cards, { newLimit: 2, sessionLimit: 100 });
+
+    expect(q.filter((id) => id.startsWith('fresh-'))).toHaveLength(2);
+    expect(q.filter((id) => id.startsWith('card-'))).toHaveLength(3);
+  });
+
+  test('a card that is not yet due stays out of the queue', () => {
+    const cards: Record<string, CardState> = {
+      early: { ...seen('early', 1), due: Date.now() + 5 * DAY },
+      ready: seen('ready', 1),
+    };
+
+    expect(buildQueue(['early', 'ready'], cards, NO_NEW)).toEqual(['ready']);
+  });
+});


### PR DESCRIPTION
Closes #11.

The queue was fully deterministic — due cards sorted by overdue-ness, new cards in item order, interleaved, then cut. Same cards, same order, every day, which is how you end up recalling the *sequence* instead of the answer.

`buildQueue` now shuffles what it presents.

## The part I deliberately did not change

`buildQueue` does two separable jobs, and only the second one was broken:

| Job | Behaviour | Changed? |
|---|---|---|
| **Selecting** which cards the session holds | sort by overdue-ness → interleave books → cut to `sessionLimit` | **No** |
| **Presenting** them | was: same order every day | **Yes** — shuffled |

The selection ordering is what makes a truncated session the *right* session: most urgent cards first, spread across books rather than the first N of one. Shuffling before the cut would have quietly thrown that away — you would get a random 20 cards instead of the 20 most overdue. So the shuffle happens strictly after `.slice()`, and the scheduling guarantees are untouched.

## Tests

The risk with this change is fixing the presentation and silently breaking the selection, so `tests/e2e/queue.spec.ts` pins both halves:

- presentation order varies between sessions (8 runs of a 30-card deck must all differ — odds of an honest collision are 1/30!)
- no card is lost, duplicated, or invented
- **a truncated session still takes the five most overdue cards**
- the new-card cap still holds
- a card that is not yet due stays out

The third one is the real regression guard. It fails if anyone later moves the shuffle above the `.slice()`.

I put these in a new file rather than editing the existing specs — it is a new concern, and it keeps the diff off the suite another session is actively working in.

## Verified

- `npx tsc -b` clean
- `npm run validate` — all checks pass
- `npx playwright test --workers=2` — **87 passed** (82 existing + 5 new), exit 0

No existing spec needed changing: `reviewOne` seeds a single-card queue, and the one multi-card spec asserts a count rather than an order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)