### PR TITLE
Give the e2e boot wait its own timeout

### DIFF
--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -111,10 +111,28 @@ export async function seed(page: Page, options: SeedOptions = {}): Promise<void>
   }, payload);
 }
 
+/**
+ * How long to allow for the app to boot.
+ *
+ * The splash holds for a deliberate minimum — `SPLASH_MIN_MS`, 1100ms in
+ * src/App.tsx — so it reads as a screen rather than a flicker, and a cold first
+ * load also pays for the dev server transforming the whole item bank. That is a
+ * known, intended delay sitting inside what would otherwise be the generic 5s
+ * expect timeout, which leaves very little headroom on a loaded machine. So the
+ * wait carries its own budget instead. It is still a bounded wait: a genuine
+ * hang fails the test rather than stalling the run.
+ */
+export const BOOT_TIMEOUT_MS = 20_000;
+
+/** Wait for the boot splash to hand off to the app. */
+export async function expectBooted(page: Page): Promise<void> {
+  await expect(page.locator('.boot-splash')).toBeHidden({ timeout: BOOT_TIMEOUT_MS });
+}
+
 /** Navigate to a tab and wait out the boot splash's minimum hold. */
 export async function openApp(page: Page, tab = 'home'): Promise<void> {
   await page.goto(`/#${tab}`);
-  await expect(page.locator('.boot-splash')).toBeHidden();
+  await expectBooted(page);
 }
 
 /** Seed a member, then open the app — the common two-line preamble. */

--- a/tests/e2e/mobile-gate.spec.ts
+++ b/tests/e2e/mobile-gate.spec.ts
@@ -19,6 +19,8 @@ test.describe('mobile gate', () => {
 
     await expect(page.getByRole('button')).toHaveCount(0);
     await expect(page.getByRole('navigation')).toBeHidden();
+    // Not expectBooted(): this asserts the splash was never shown at all — the
+    // gate refuses before it — rather than waiting for boot to finish.
     await expect(page.locator('.boot-splash')).toBeHidden();
   });
 

--- a/tests/e2e/progress.spec.ts
+++ b/tests/e2e/progress.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { readFileSync } from 'node:fs';
-import { ITEM, daysFromNow, daysUntil, dueCard, expectStat, leechCard, openApp, openAs, readStore, seed, storeWith } from './harness';
+import { ITEM, daysFromNow, daysUntil, dueCard, expectBooted, expectStat, leechCard, openApp, openAs, readStore, seed, storeWith } from './harness';
 
 test.describe('progress and settings', () => {
   test('session limits are editable and survive a reload', async ({ page }) => {
@@ -12,7 +12,7 @@ test.describe('progress and settings', () => {
     expect((await readStore(page)).settings).toMatchObject({ newLimit: 35, sessionLimit: 120 });
 
     await page.reload();
-    await expect(page.locator('.boot-splash')).toBeHidden();
+    await expectBooted(page);
     await expect(page.locator('#nl')).toHaveValue('35');
     await expect(page.locator('#sl')).toHaveValue('120');
   });

--- a/tests/e2e/shell.spec.ts
+++ b/tests/e2e/shell.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { MEMBER, OUTSIDER, expectStat, openApp, openAs, seed } from './harness';
+import { BOOT_TIMEOUT_MS, MEMBER, OUTSIDER, expectStat, openApp, openAs, seed } from './harness';
 
 test.describe('shell and auth', () => {
   test('a signed-out visitor gets the sign-in prompt, not the app', async ({ page }) => {
@@ -46,7 +46,7 @@ test.describe('shell and auth', () => {
 
     const splash = page.locator('.boot-splash');
     await expect(splash).toHaveAttribute('aria-label', 'Scripture Mastery — Loading…');
-    await expect(splash).toBeHidden();
+    await expect(splash).toBeHidden({ timeout: BOOT_TIMEOUT_MS });
     await expect(page.getByRole('navigation')).toBeVisible();
   });
 


### PR DESCRIPTION
Follow-up to #18, prompted by the other session hitting random boot-wait timeouts while both agents were competing for this machine.

## The problem

The boot splash holds for a **deliberate** minimum — `SPLASH_MIN_MS`, 1100ms in `src/App.tsx` — so it reads as a screen rather than a flicker. A cold first load also pays for the dev server transforming the whole item bank. That known, intended delay was sitting inside Playwright's generic 5s expect timeout, which leaves very little headroom on a loaded machine.

The result: the boot wait was the first thing to time out under contention, and it failed as a bare "element not hidden" that tells you nothing about *why*.

## The change

Centralised as `expectBooted()` in the harness, with a documented 20s budget and the reasoning written down next to it. It is still a **bounded** wait — a genuine hang fails the test rather than stalling the run.

The mobile gate deliberately keeps the plain assertion, with a comment saying why: there it means "the splash was never shown", since the gate refuses before it, not "wait for boot to finish". Worth pinning so it doesn't get "helpfully" converted later.

## Deliberately not done

Pinning `workers` in `playwright.config.ts`. Two agent sessions fighting over 8 cores is not a condition a real contributor hits, and a global worker cap would hide genuine slowness from CI. `--workers=2` stays an operator choice for a loaded box.

## Verification

Test-only — no production code touched. Typecheck clean, 82 passed locally on current `main` (including #21 and #24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)