### PR TITLE
Draw Events options from the same division

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Events options now come from the same division** ([#12]). "In which book do
+  we read about this: Miriam's leprosy?" now offers Genesis, Exodus and
+  Leviticus against Numbers — the books of Moses — instead of anything in the
+  canon. Reuses the `nearbyPool` widening added in [#10], so short divisions
+  reach into adjacent ones and nothing ever crosses the Old/New Testament seam.
+  Applies to all four Events generators: the two whose answer is a book name,
+  and the two whose options are event text. Verified against the bank: across
+  932 book-answered Events questions, zero options cross the Testament boundary
+  and zero fall outside the neighbourhood, with every question still offering
+  four choices.
+
 - **Daily review questions are shuffled** ([#11]). The queue was fully
   deterministic, so the same cards arrived in the same order every day and you
   could start recalling the sequence instead of the answer. `buildQueue` now
@@ -84,3 +95,5 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [#10]: https://github.com/godwinlaw/scripture-mastery/issues/10
 
 [#11]: https://github.com/godwinlaw/scripture-mastery/issues/11
+
+[#12]: https://github.com/godwinlaw/scripture-mastery/issues/12

--- a/src/lib/generate-detail.ts
+++ b/src/lib/generate-detail.ts
@@ -9,8 +9,6 @@ const bookAbbr = new Map(BOOKS.map((b) => [b.id, b.abbr]));
 /** Lets a Book-keyed pool walk reach that book's detail entry (#10). */
 const detailByBook = new Map(DETAILS.map((d) => [d.book, d]));
 
-/** Every "what" across every book — the pool for chapter-content distractors. */
-const allEventWhats = DETAILS.flatMap((d) => d.events.map((e) => e.what));
 const allFigureDeeds = DETAILS.flatMap((d) => d.figures.map((f) => f.did));
 const allFigureNames = [...new Set(DETAILS.flatMap((d) => d.figures.map((f) => f.name)))];
 const allNumberValues = DETAILS.flatMap((d) => d.numbers?.map((n) => n.value) ?? []);
@@ -85,7 +83,12 @@ function eventItems(d: BookDetail): Item[] {
         : `${ref(d, e.ref)} — what happens?`,
       answer: e.what,
       distractors: pickDistractors(
-        ownWhats.length >= 6 ? ownWhats : allEventWhats, e.what, 3, `evw-${key}`,
+        // Own book first, as before. The fallback used to be the whole canon;
+        // it is now the surrounding division, widening only as needed (#12).
+        ownWhats.length >= 6
+          ? ownWhats
+          : nearbyPool(d.book, (x) => (detailByBook.get(x.id)?.events ?? []).map((y) => y.what), e.what),
+        e.what, 3, `evw-${key}`,
       ),
       explain: [e.detail, e.where ? `Where: ${e.where}.` : null].filter(Boolean).join(' '),
     });
@@ -110,7 +113,10 @@ function eventItems(d: BookDetail): Item[] {
     // that records it is kept out of the distractor pool.
     if (eventNameOwner.get(e.name.toLowerCase()) === d.book) {
       const banned = booksWithEventName(e.name);
-      const pool = BOOKS.map((b) => b.name).filter((n) => !banned.has(n));
+      // Same-division books, widening only as far as it must — "Miriam's
+      // leprosy" should offer the books of Moses, not Colossians (#12). The
+      // ban is folded in so the widening counts only offerable books.
+      const pool = nearbyPool(d.book, (x) => (banned.has(x.name) ? [] : [x.name]), name);
       items.push({
         id: `det-ev-book-${key}`, kind: 'mcq', topic: 'events', tier: 2, book: d.book,
         prompt: `In which book do we read about this: ${e.name}?`,
@@ -149,7 +155,11 @@ function eventItems(d: BookDetail): Item[] {
 
     // The detail that separates this episode from every similar one.
     if (e.detail) {
-      const details = DETAILS.flatMap((x) => x.events.map((y) => y.detail)).filter((x): x is string => !!x);
+      const details = nearbyPool(
+        d.book,
+        (x) => (detailByBook.get(x.id)?.events ?? []).map((y) => y.detail).filter((y): y is string => !!y),
+        e.detail,
+      );
       items.push({
         id: `det-ev-detail-${key}`, kind: 'mcq', topic: 'events', tier: 3, book: d.book,
         prompt: `Which detail belongs to this episode: ${e.name} (${ref(d, e.ref)})?`,

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -93,13 +93,15 @@ function buildBookItems(): Item[] {
       const key = eventKey(ev);
       if (eventOwner.get(key) !== b.id) continue; // one item per event, first book wins
       const banned = booksRecording(ev);
-      const pool = siblingNames(b.id).filter((n) => !banned.has(n));
-      const fallback = pool.length >= 3 ? pool : bookNames.filter((n) => !banned.has(n));
+      // The ban is folded into the extract rather than applied afterwards, so
+      // the widening in nearbyPool counts only books it can actually offer —
+      // filtering after the fact could leave a division short and still stop (#12).
+      const pool = nearbyPool(b.id, (x) => (banned.has(x.name) ? [] : [x.name]), b.name);
       items.push({
         id: `gen-event-${b.id}-${slug(ev)}`, kind: 'mcq', topic: 'events', tier: 2, book: b.id,
         prompt: `In which book does this occur: ${ev}?`,
         answer: b.name,
-        distractors: pickDistractors(fallback, b.name, 3, `ev-${b.id}-${ev}`),
+        distractors: pickDistractors(pool, b.name, 3, `ev-${b.id}-${ev}`),
         explain: b.oneLine,
       });
     }


### PR DESCRIPTION
Closes #12.

The issue’s own example, now:

> **In which book do we read about this: Miriam’s leprosy?**
> ✓ Numbers
> ✗ Leviticus *(Law)* ✗ Exodus *(Law)* ✗ Genesis *(Law)*

The books of Moses, as asked.

## Reuses #10 rather than duplicating it

This is what the `extract` callback on `nearbyPool` was for — short divisions reach into adjacent ones, nothing crosses the Testament seam, and there is one widening rule rather than two.

## The ban / widening interaction, which is the subtle bit

Events appearing in several books (the Transfiguration is in three Gospels) already excluded every book that also records them, or a right answer would score as wrong.

That exclusion is now folded **into the extract** rather than applied to the result. Filtering afterwards could leave a division one book short and still stop widening — the pool has to count only books it can actually offer. Applying the ban after the fact would have produced three-option questions in exactly the cases the ban matters.

## Coverage

| Generator | Options are | Change |
|---|---|---|
| `gen-event` | book names | division pool, ban folded in |
| `det-ev-book` | book names | division pool, ban folded in |
| `det-ev-what` | event text | keeps own-book preference; fallback canon-wide → division |
| `det-ev-detail` | event text | division pool |

`allEventWhats` had no readers left and is gone. Authored items in `extras.ts` are untouched — their distractors were hand-picked and already sensible.

## Verified against the bank

| Check | Result |
|---|---|
| Events mcq items | 1,615 |
| …answered by a book name | 932 |
| **Cross-Testament options** | **0** |
| Outside the neighbourhood | 0 |
| mcq anywhere with <3 distractors | 0 |

## One note on the issue text

The issue says *"Since the answer is Exodus"* for Miriam’s leprosy — it is Numbers 12, and the app already had it right. Doesn’t change the fix; flagging only so the example reads correctly if you revisit it.

## Verified

- `npx tsc -b` clean
- `npm run validate` — all checks pass
- `npx playwright test --workers=2` — **87 passed**, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)