### PR TITLE
Rename the middle grade button from Good to Ok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **The middle grade button reads "Ok" rather than "Good"** ([#15]). Its keyboard
+  shortcut, scheduling behaviour, and "normal pace" hint are unchanged — this is
+  the label only. "Good" sat oddly next to "Hard", reading as a judgement on the
+  answer rather than on how easily it came back.
+
 - **Events options now come from the same division** ([#12]). "In which book do
   we read about this: Miriam's leprosy?" now offers Genesis, Exodus and
   Leviticus against Numbers — the books of Moses — instead of anything in the
@@ -97,3 +102,5 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [#11]: https://github.com/godwinlaw/scripture-mastery/issues/11
 
 [#12]: https://github.com/godwinlaw/scripture-mastery/issues/12
+
+[#15]: https://github.com/godwinlaw/scripture-mastery/issues/15

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -222,7 +222,7 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
                   <span className="hint">see it more often</span>
                 </button>
                 <button className="btn primary sm" onClick={() => onGrade(2)}>
-                  Good <span className="kbd">2</span>
+                  Ok <span className="kbd">2</span>
                   <span className="hint">normal pace</span>
                 </button>
                 <button className="btn sm" onClick={() => onGrade(3)}>

--- a/src/lib/srs.ts
+++ b/src/lib/srs.ts
@@ -5,7 +5,7 @@
  */
 import { shuffle } from './rng';
 
-export type Grade = 0 | 1 | 2 | 3; // again | hard | good | easy
+export type Grade = 0 | 1 | 2 | 3; // again | hard | ok | easy
 
 export interface CardState {
   id: string;

--- a/tests/e2e/question-kinds.spec.ts
+++ b/tests/e2e/question-kinds.spec.ts
@@ -46,8 +46,8 @@ test.describe('multiple choice', () => {
     await choice(page, 'Exodus').click();
 
     await expect(page.locator('.feedback.correct')).toContainText('Correct');
-    await expect(page.getByRole('button', { name: /^Good/ })).toBeVisible();
-    await page.getByRole('button', { name: /^Good/ }).click();
+    await expect(page.getByRole('button', { name: /^Ok/ })).toBeVisible();
+    await page.getByRole('button', { name: /^Ok/ }).click();
 
     const store = await readStore(page);
     expect(store.cards[ITEM.mcq].reps).toBe(3);
@@ -64,7 +64,7 @@ test.describe('multiple choice', () => {
     await expect(page.locator('.choice.correct')).toHaveText(/Exodus/);
     await expect(page.locator('.choice.wrong')).toHaveText(/Deuteronomy/);
     // A miss offers no self-grading — it goes back in the queue as "again".
-    await expect(page.getByRole('button', { name: /^Good/ })).toBeHidden();
+    await expect(page.getByRole('button', { name: /^Ok/ })).toBeHidden();
     await expect(page.getByRole('button', { name: /^Continue/ })).toBeVisible();
   });
 
@@ -91,7 +91,7 @@ test.describe('multiple choice', () => {
 
     await page.keyboard.press('3'); // Easy
     const store = await readStore(page);
-    // Easy nudges ease up from the 2.5 default; Good would have left it alone.
+    // Easy nudges ease up from the 2.5 default; Ok would have left it alone.
     expect(store.cards[ITEM.mcq].ease).toBeCloseTo(2.6, 5);
     expect(store.cards[ITEM.mcq].recent.at(-1)).toBe(3);
   });

--- a/tests/e2e/quiz.spec.ts
+++ b/tests/e2e/quiz.spec.ts
@@ -79,7 +79,7 @@ test.describe('mixed quiz', () => {
     await scope(page, 'Starred').click();
     await page.getByRole('button', { name: 'Start quiz' }).click();
     await page.locator('.choice').filter({ has: page.getByText('Exodus', { exact: true }) }).click();
-    await page.getByRole('button', { name: /^Good/ }).click();
+    await page.getByRole('button', { name: /^Ok/ }).click();
 
     await expect(cardTitle(page, 'Quiz complete')).toBeVisible();
     await expectStat(page, 'correct out of 1', 1);
@@ -92,7 +92,7 @@ test.describe('mixed quiz', () => {
     await scope(page, 'Starred').click();
     await page.getByRole('button', { name: 'Start quiz' }).click();
     await page.locator('.choice').filter({ has: page.getByText('Exodus', { exact: true }) }).click();
-    await page.getByRole('button', { name: /^Good/ }).click();
+    await page.getByRole('button', { name: /^Ok/ }).click();
 
     await page.getByRole('button', { name: 'Retake' }).click();
     await expect(page.getByRole('progressbar', { name: 'Progress: question 1 of 1' })).toBeVisible();
@@ -126,7 +126,7 @@ test.describe('mixed quiz', () => {
     await scope(page, 'Starred').click();
     await page.getByRole('button', { name: 'Start quiz' }).click();
     await page.locator('.choice').filter({ has: page.getByText('Exodus', { exact: true }) }).click();
-    await page.getByRole('button', { name: /^Good/ }).click();
+    await page.getByRole('button', { name: /^Ok/ }).click();
     await expect(cardTitle(page, 'Quiz complete')).toBeVisible();
 
     const store = await readStore(page);

--- a/tests/e2e/review.spec.ts
+++ b/tests/e2e/review.spec.ts
@@ -31,7 +31,7 @@ test.describe('daily review', () => {
     await expect(page.getByText('1 / 1')).toBeVisible();
 
     await answerMcq(page, 'Exodus');
-    await page.getByRole('button', { name: /^Good/ }).click();
+    await page.getByRole('button', { name: /^Ok/ }).click();
 
     await expect(page.getByRole('heading', { name: 'Session complete' })).toBeVisible();
     await expectStat(page, 'Answered', 1);
@@ -112,7 +112,7 @@ test.describe('daily review', () => {
     await openAs(page, { store: soloQueue(ITEM.mcq) }, 'review');
     await start(page);
     await answerMcq(page, 'Exodus');
-    await page.getByRole('button', { name: /^Good/ }).click();
+    await page.getByRole('button', { name: /^Ok/ }).click();
 
     await expect(page.getByRole('heading', { name: 'Session complete' })).toBeVisible();
     await page.getByRole('button', { name: 'Done' }).click();


### PR DESCRIPTION
Closes #15.

Hard / **Ok** / Easy.

"Good" sat oddly beside "Hard" — it reads as a verdict on the answer rather than on how easily it came back, which is the only thing the grade actually means.

**Label only.** The keyboard shortcut (`2`), the `Grade` value, the scheduling maths, and the "normal pace" hint are all untouched.

Also updates the nine spec references that matched the button by accessible name, and the `Grade` type comment so it still describes what the UI says.

## Verified

- `npx tsc -b` clean
- `npm run validate` — all checks pass
- `npx playwright test --workers=2` — **87 passed**, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)