### PR TITLE
Drop Christ in Scripture as a study category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
+- **"Christ in Scripture" is no longer a study category** ([#16]). The topic is
+  gone from the `Topic` union, the topic labels, both study-plan phases that
+  listed it, and the 66 "How does X point to Christ?" questions it generated.
+  The answers there are interpretive rather than recall, which made a
+  four-option quiz the wrong shape for them.
+  **The content itself is kept.** Every book's `christ` line still appears in
+  the Library's book panel and is still searchable — it is reference material
+  now rather than a question.
+
 - **Chapter-count questions** ([#8]). The 66 per-book "How many chapters are in
   X?" items are gone, along with "How many chapters are in the whole Bible?"
   (1,189) — the same species of question in the same topic. Their answer is a
@@ -104,3 +113,5 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [#12]: https://github.com/godwinlaw/scripture-mastery/issues/12
 
 [#15]: https://github.com/godwinlaw/scripture-mastery/issues/15
+
+[#16]: https://github.com/godwinlaw/scripture-mastery/issues/16

--- a/src/data/plan.ts
+++ b/src/data/plan.ts
@@ -64,7 +64,7 @@ export const PHASES: Phase[] = [
     name: 'Phase 4 — Timeline & Connections',
     goal: 'Lock the chronology and the standing lists, then connect books to eras.',
     weight: 2,
-    topics: ['timeline', 'numbers', 'summaries', 'christ'],
+    topics: ['timeline', 'numbers', 'summaries'],
     scope: 'all',
     drills: [
       'Put the 14 eras in order from memory',
@@ -72,7 +72,6 @@ export const PHASES: Phase[] = [
       'Walk the must-know indexes out loud: Genesis, John, Acts, the key epistle chapters',
       'Place every book on the timeline',
       'Memorize the two fall dates: 722 BC and 586 BC',
-      'For each book, say in one sentence how it points to Christ',
     ],
   },
   {
@@ -80,7 +79,7 @@ export const PHASES: Phase[] = [
     name: 'Phase 5 — Mixed Review & Mock Quizzes',
     goal: 'No new material. Mixed review, weak spots, and full-length practice under time.',
     weight: 2,
-    topics: ['book-order', 'summaries', 'chapters', 'people', 'relationships', 'events', 'places', 'timeline', 'numbers', 'christ'],
+    topics: ['book-order', 'summaries', 'chapters', 'people', 'relationships', 'events', 'places', 'timeline', 'numbers'],
     scope: 'all',
     drills: [
       'Take a 40-question mixed quiz every other day',

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -84,8 +84,7 @@ export type Topic =
   | 'events'
   | 'places'
   | 'timeline'
-  | 'numbers'
-  | 'christ';
+  | 'numbers';
 
 export const TOPIC_LABELS: Record<Topic, string> = {
   'book-order': 'Book Order',
@@ -97,5 +96,4 @@ export const TOPIC_LABELS: Record<Topic, string> = {
   places: 'Places',
   timeline: 'Timeline',
   numbers: 'Numbers & Counts',
-  christ: 'Christ in Scripture',
 };

--- a/src/lib/generate-detail.ts
+++ b/src/lib/generate-detail.ts
@@ -12,7 +12,6 @@ const detailByBook = new Map(DETAILS.map((d) => [d.book, d]));
 const allFigureDeeds = DETAILS.flatMap((d) => d.figures.map((f) => f.did));
 const allFigureNames = [...new Set(DETAILS.flatMap((d) => d.figures.map((f) => f.name)))];
 const allNumberValues = DETAILS.flatMap((d) => d.numbers?.map((n) => n.value) ?? []);
-const allChristLines = DETAILS.map((d) => d.christ);
 const allPurposes = DETAILS.map((d) => d.purpose);
 const allAudiences = [...new Set(DETAILS.map((d) => d.audience))];
 const allWritten = [...new Set(DETAILS.map((d) => d.written))];
@@ -305,13 +304,11 @@ function frameItems(d: BookDetail): Item[] {
     explain: `${name}: ${d.purpose}.`,
   });
 
-  items.push({
-    id: `det-christ-${d.book}`, kind: 'mcq', topic: 'christ', tier: 2, book: d.book,
-    prompt: `How does ${name} point to Christ?`,
-    answer: d.christ,
-    distractors: pickDistractors(allChristLines, d.christ, 3, `chr-${d.book}`),
-    explain: d.purpose,
-  });
+  // "How does X point to Christ?" was generated here as its own topic. #16
+  // dropped it as a study category: the answers are interpretive rather than
+  // recall, so a four-option quiz was the wrong shape for them. The `christ`
+  // line survives on BookDetail and still reads in the Library panel — it is
+  // reference material now, not a question.
 
   if (d.distinctive && isPropheticBook(d.book)) {
     items.push({


### PR DESCRIPTION
Closes #16.

Removes the `christ` topic from:

- the `Topic` union and `TOPIC_LABELS`
- both study-plan phases that listed it
- the 66 generated "How does *X* point to Christ?" questions

The answers there are interpretive rather than recall, which made a four-option multiple choice the wrong shape for them — three wrong answers to a question like that are not so much wrong as *someone else’s book*.

## What is deliberately kept

**The content.** Every book’s `christ` line stays on `BookDetail`, still renders in the Library’s book panel (`Christ in Genesis: …`), and is still searchable there. This removes a *category of questions*, not the material.

## One judgement call

The study plan’s Phase 4 drill — *"For each book, say in one sentence how it points to Christ"* — also goes. It was pointing at a category that no longer exists. It is a self-directed drill rather than a generated question, so leaving it would have been defensible; I removed it because a study plan telling you to drill a removed category reads as an oversight. One line to restore if you disagree.

`allChristLines` had no readers left afterwards.

## Note

Rebased onto `main` after #15 landed — the changelog needed both link refs, and folding this entry into the existing `### Removed` section rather than opening a second one.

## Verified

- `npx tsc -b` clean
- `npm run validate` — all checks pass
- `npx playwright test --workers=2` — **87 passed**, exit 0 (re-run after the rebase, not before)
- No `'christ'` topic reference remains anywhere in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)