### PR TITLE
Offer a typed reference for a bonus before the choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Added
+
+- **Type the reference for a bonus** ([#14]). Questions whose answer is a place
+  in scripture — 1,067 of them, about 17% of the bank — now ask you to name it
+  before showing any options at all. *Where does this happen? "The walls of
+  Jericho fall after seven days of marching"* opens on a text box, not four
+  choices. Name it and the card files itself as **Easy** without asking you to
+  grade it; naming a reference is a strictly harder thing than recognising one.
+  Abbreviations are fine ("Josh 6" = "Joshua 6"), and so is extra precision —
+  "Genesis 3:15" answers a question about Genesis 3, because more knowledge
+  should never score worse. One attempt: a wrong guess costs the bonus but not
+  the question, dropping you to the ordinary multiple choice, and
+  "Show me the choices" declines the bonus outright for a normal score.
+  References are parsed structurally rather than compared as text, so "Genesis
+  3" cannot answer "Genesis 30" and the colon in "1 Cor 15:1-8" survives.
+
+- **App icon** ([#7]). The "Blade on the page" mark (design 2a) — a paper ribbon
+  marker on a steel field with the sword of Hebrews 4:12 struck through it.
+  Shipped in two cuts, since the design gives small sizes their own treatment:
+  `favicon.svg` widens the blade and drops the passage rules that turn to mush
+  in a browser tab, while `icon.svg` keeps the full detail for app tiles.
+  Adds `apple-touch-icon.png` (180), `icon-192.png`, `icon-512.png`, and a web
+  manifest, so the app installs with a real icon rather than a blank tile.
+  Colours are the app's existing tokens (`--color-accent-900` steel,
+  `--color-bg` paper, `--color-accent` rules), written as literals because an
+  SVG loaded as a favicon never sees the document's custom properties.
+
 ### Changed
 
 - **Question cues name their subject instead of opening on a bare pronoun**
@@ -104,19 +131,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   submitted an arrangement without ever checking it, turning the race into a
   confusing count mismatch three assertions later.
 
-### Added
-
-- **App icon** ([#7]). The "Blade on the page" mark (design 2a) — a paper ribbon
-  marker on a steel field with the sword of Hebrews 4:12 struck through it.
-  Shipped in two cuts, since the design gives small sizes their own treatment:
-  `favicon.svg` widens the blade and drops the passage rules that turn to mush
-  in a browser tab, while `icon.svg` keeps the full detail for app tiles.
-  Adds `apple-touch-icon.png` (180), `icon-192.png`, `icon-512.png`, and a web
-  manifest, so the app installs with a real icon rather than a blank tile.
-  Colours are the app's existing tokens (`--color-accent-900` steel,
-  `--color-bg` paper, `--color-accent` rules), written as literals because an
-  SVG loaded as a favicon never sees the document's custom properties.
-
 [#7]: https://github.com/godwinlaw/scripture-mastery/issues/7
 
 [#8]: https://github.com/godwinlaw/scripture-mastery/issues/8
@@ -130,6 +144,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [#12]: https://github.com/godwinlaw/scripture-mastery/issues/12
 
 [#13]: https://github.com/godwinlaw/scripture-mastery/issues/13
+
+[#14]: https://github.com/godwinlaw/scripture-mastery/issues/14
 
 [#15]: https://github.com/godwinlaw/scripture-mastery/issues/15
 

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { TOPIC_LABELS, type Item } from '../data/types';
 import type { Grade } from '../lib/srs';
 import { shuffle } from '../lib/rng';
+import { isReference, referenceMatches } from '../lib/reference';
 
 interface Props {
   item: Item;
@@ -46,6 +47,18 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
   const [arranged, setArranged] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  /**
+   * Questions whose answer is a place in scripture open with a chance to name
+   * it from memory, before any options are on screen (#14). Naming a reference
+   * is strictly harder than recognising one, so getting it this way is worth a
+   * grade you would otherwise have to award yourself.
+   */
+  const hasBonusRound = item.kind === 'mcq' && isReference(item.answer);
+  const [bonusOpen, setBonusOpen] = useState(hasBonusRound);
+  const [bonusMissed, setBonusMissed] = useState(false);
+  /** Named the reference unprompted — the card grades itself Easy on advance. */
+  const [bonusEarned, setBonusEarned] = useState(false);
+
   const options = useMemo(
     () => (item.kind === 'mcq' ? shuffle([item.answer, ...(item.distractors ?? [])]) : []),
     // Reshuffle per item so the answer is not always in the same slot.
@@ -58,11 +71,37 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
     setRevealed(false);
     setWasCorrect(false);
     setArranged(item.kind === 'order' ? shuffle(item.sequence ?? []) : []);
-    if (item.kind === 'type') setTimeout(() => inputRef.current?.focus(), 30);
+    setBonusOpen(hasBonusRound);
+    setBonusMissed(false);
+    setBonusEarned(false);
+    if (item.kind === 'type' || hasBonusRound) setTimeout(() => inputRef.current?.focus(), 30);
   }, [item.id]);
 
   function resolve(correct: boolean) {
     setWasCorrect(correct);
+    setRevealed(true);
+  }
+
+  /** Give up on the bonus and show the four options at the normal score. */
+  function showChoices() {
+    setBonusOpen(false);
+    setTyped('');
+  }
+
+  function submitReference() {
+    if (revealed || !bonusOpen) return;
+    if (!referenceMatches(typed, item.answer)) {
+      // One attempt. A wrong guess costs the bonus, not the question — the
+      // options appear and the card is scored the ordinary way from here.
+      setBonusMissed(true);
+      showChoices();
+      return;
+    }
+    // Reveal first. Grading immediately would advance the session before the
+    // member ever saw "Correct" or the explanation, which is the part of a
+    // right answer worth keeping.
+    setBonusEarned(true);
+    setWasCorrect(true);
     setRevealed(true);
   }
 
@@ -95,18 +134,26 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
     function onKey(e: KeyboardEvent) {
       const typing = document.activeElement?.tagName === 'INPUT';
       if (!revealed) {
-        if (item.kind === 'mcq' && /^[1-4]$/.test(e.key)) {
+        // While the bonus round is up the options are not on screen, so the
+        // number keys must not reach behind it and answer for you.
+        if (item.kind === 'mcq' && !bonusOpen && /^[1-4]$/.test(e.key)) {
           const opt = options[Number(e.key) - 1];
           if (opt) { e.preventDefault(); choose(opt); }
         }
         if (e.key === 'Enter') {
           e.preventDefault();
-          if (item.kind === 'type') submitTyped();
-          if (item.kind === 'order') submitOrder();
+          if (bonusOpen) submitReference();
+          else if (item.kind === 'type') submitTyped();
+          else if (item.kind === 'order') submitOrder();
         }
         return;
       }
       if (typing) return;
+      if (bonusEarned) {
+        // No grade to choose — Enter just advances, filed as Easy.
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onGrade(3); }
+        return;
+      }
       if (!wasCorrect) {
         if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onGrade(0); }
         return;
@@ -118,7 +165,7 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
     }
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [revealed, wasCorrect, options, item.id, typed, arranged]);
+  }, [revealed, wasCorrect, options, item.id, typed, arranged, bonusOpen, bonusEarned]);
 
   const correctIndex = (item.sequence ?? []).reduce<Record<string, number>>((m, s, i) => ({ ...m, [s]: i }), {});
 
@@ -144,8 +191,41 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
 
       <p className="q-prompt">{item.prompt}</p>
 
-      {item.kind === 'mcq' && (
+      {bonusOpen && (
+        <div>
+          <input
+            ref={inputRef}
+            className="answer"
+            value={typed}
+            disabled={revealed}
+            placeholder="Type the reference, e.g. Josh 6"
+            aria-label="Type the reference for a bonus"
+            onChange={(e) => setTyped(e.target.value)}
+          />
+          {/* Once it is answered the round is over: leave what was typed on
+              screen, but take away the controls that would re-open it. */}
+          {!revealed && (
+            <>
+              <div className="row" style={{ marginTop: 12 }}>
+                <button className="btn primary" onClick={submitReference}>Check reference</button>
+                <button className="btn sm" onClick={showChoices}>Show me the choices</button>
+              </div>
+              <p className="tiny muted" style={{ marginTop: 10, marginBottom: 0 }}>
+                Name it and the card grades itself Easy. Abbreviations are fine.
+                Take the choices instead and it scores as normal.
+              </p>
+            </>
+          )}
+        </div>
+      )}
+
+      {item.kind === 'mcq' && !bonusOpen && (
         <div className="choices">
+          {bonusMissed && !revealed && (
+            <p className="tiny muted" style={{ margin: '0 0 10px' }}>
+              Not that reference — no bonus. Pick it from the choices instead.
+            </p>
+          )}
           {options.map((opt, i) => {
             const cls = !revealed ? '' : opt === item.answer ? ' correct' : opt === picked ? ' wrong' : '';
             return (
@@ -215,7 +295,16 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
           {item.explain && <div className="why">{item.explain}</div>}
 
           <div className="row" style={{ marginTop: 14 }}>
-            {wasCorrect ? (
+            {bonusEarned ? (
+              // Named unprompted, which is the strongest evidence of recall
+              // this app can collect — so it grades itself Easy rather than
+              // asking. The button still exists, to keep the explanation on
+              // screen until the member is done reading it.
+              <button className="btn primary sm" onClick={() => onGrade(3)}>
+                Continue <span className="kbd">↵</span>
+                <span className="hint">named it — filed as Easy</span>
+              </button>
+            ) : wasCorrect ? (
               <>
                 <button className="btn sm" onClick={() => onGrade(1)}>
                   Hard <span className="kbd">1</span>

--- a/src/lib/reference.ts
+++ b/src/lib/reference.ts
@@ -1,0 +1,96 @@
+/**
+ * Recognising and comparing Bible references, for the typed bonus round (#14).
+ *
+ * A reference-answered question is one whose answer is a place in scripture
+ * rather than a fact about it — "Joshua 6", "1 Cor 15:1-8". Those are the
+ * questions worth letting someone answer from memory before showing them four
+ * options, because naming the reference is a strictly harder thing to do than
+ * recognising it.
+ */
+import { BOOKS } from '../data/books';
+
+/**
+ * Every way a book can be written, longest first so that "1 John" wins over
+ * "John" and "Song of Songs" over "Song".
+ */
+const BOOK_LABELS: { label: string; id: string }[] = BOOKS
+  .flatMap((b) => [
+    { label: b.name, id: b.id },
+    { label: b.abbr, id: b.id },
+  ])
+  .sort((a, b) => b.label.length - a.label.length);
+
+function escape(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** "Joshua 6", "Josh 6", "1 Cor 15:1-8" — a book label followed by a number. */
+const REFERENCE = new RegExp(`^(?:${BOOK_LABELS.map((b) => escape(b.label)).join('|')})\\s+\\d`, 'i');
+
+/** Whether an answer names a place in scripture, and so earns a typed round. */
+export function isReference(answer: string): boolean {
+  return REFERENCE.test(answer.trim());
+}
+
+interface ParsedReference {
+  /** Canonical book id, so "Josh" and "Joshua" compare equal. */
+  book: string;
+  /** Everything after the book name, normalised: "1-2", "15:1-8". */
+  locus: string;
+}
+
+/**
+ * Splits a reference into the book it names and the part that locates it.
+ * Returns null for anything that does not start with a book we know.
+ */
+export function parseReference(input: string): ParsedReference | null {
+  const text = input
+    .trim()
+    // en/em dashes and the various apostrophes people actually type
+    .replace(/[\u2012-\u2015]/g, '-')
+    .replace(/\s+/g, ' ');
+
+  for (const { label, id } of BOOK_LABELS) {
+    // Match the label only at a word boundary, so "Job" does not swallow "John".
+    const head = new RegExp(`^${escape(label)}\\b\\.?\\s*`, 'i');
+    const m = text.match(head);
+    if (!m) continue;
+    const locus = text
+      .slice(m[0].length)
+      .toLowerCase()
+      .replace(/\s*[-–—]\s*/g, '-')
+      .replace(/\s*:\s*/g, ':')
+      .replace(/[^\d:\-,]/g, '')
+      .replace(/,+$/, '');
+    return { book: id, locus };
+  }
+  return null;
+}
+
+/**
+ * Whether a typed reference names the same place as the expected one.
+ *
+ * The book must match after abbreviation. Beyond that the rule is deliberately
+ * asymmetric: extra precision passes, missing precision does not.
+ *
+ * - Expected "Genesis 3" (a chapter): "Genesis 3" and "Genesis 3:15" both pass.
+ *   Naming the verse as well is more knowledge, not less, and a bonus that
+ *   punished it would teach people to withhold what they know.
+ * - Expected "Genesis 3:15" (a verse): only "Genesis 3:15" passes. "Genesis 3"
+ *   is vaguer than what was asked for.
+ * - "Genesis 1" never answers "Genesis 1-2". A span is a different place from
+ *   one of its chapters.
+ */
+export function referenceMatches(input: string, expected: string): boolean {
+  const got = parseReference(input);
+  const want = parseReference(expected);
+  if (!got || !want) return false;
+  if (got.book !== want.book) return false;
+  if (!got.locus || !want.locus) return false;
+  if (got.locus === want.locus) return true;
+
+  // Only a chapter-level question accepts a more precise answer, and only when
+  // the chapter part is identical.
+  if (want.locus.includes(':')) return false;
+  return got.locus.split(':')[0] === want.locus;
+}

--- a/tests/e2e/bonus-round.spec.ts
+++ b/tests/e2e/bonus-round.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * The typed bonus round (#14), driven through the real card.
+ *
+ * A question whose answer is a place in scripture asks you to name it before
+ * it will show you four options. Naming it is strictly harder than picking it,
+ * so it grades itself Easy; taking the choices instead scores as normal.
+ */
+import { expect, test, type Page } from '@playwright/test';
+import { openAs, readStore, soloQueue } from './harness';
+
+/**
+ * The issue's own example: "Israel marches around the city…" → Joshua 6.
+ * A `gen-locate` item, so its answer is a reference and it opens on the bonus.
+ */
+const REF_ITEM = 'gen-locate-joshua-6';
+
+const input = (page: Page) => page.getByRole('textbox', { name: 'Type the reference for a bonus' });
+const choices = (page: Page) => page.locator('.choice');
+
+async function reviewOne(page: Page, id: string) {
+  await openAs(page, { store: soloQueue(id) }, 'review');
+  await page.getByRole('button', { name: 'Start review session' }).click();
+}
+
+test.describe('typed reference bonus', () => {
+  test('a reference question asks you to name it before showing any options', async ({ page }) => {
+    await reviewOne(page, REF_ITEM);
+
+    await expect(page.getByText('The walls of Jericho fall after seven days of marching')).toBeVisible();
+    await expect(input(page)).toBeVisible();
+    // The whole point: the answer is not on screen to be recognised.
+    await expect(choices(page)).toHaveCount(0);
+  });
+
+  test('naming the reference grades the card Easy without asking', async ({ page }) => {
+    await reviewOne(page, REF_ITEM);
+
+    await input(page).fill('Joshua 6');
+    await page.getByRole('button', { name: 'Check reference' }).click();
+
+    await expect(page.locator('.feedback.correct')).toContainText('Correct');
+    // No grade to choose — the row is replaced by a single Continue.
+    await expect(page.getByRole('button', { name: /^Hard/ })).toBeHidden();
+    await expect(page.getByRole('button', { name: /^Ok/ })).toBeHidden();
+    await expect(page.getByRole('button', { name: /^Easy/ })).toBeHidden();
+
+    await page.getByRole('button', { name: /^Continue/ }).click();
+
+    await expect(page.getByRole('heading', { name: 'Session complete' })).toBeVisible();
+    const store = await readStore(page);
+    // Easy is grade 3, which pushes ease above the 2.5 default.
+    expect(store.cards[REF_ITEM].ease).toBeGreaterThan(2.5);
+    expect(store.log.at(-1)).toMatchObject({ reviewed: 1, correct: 1 });
+  });
+
+  test('winning the bonus closes the round rather than leaving it open', async ({ page }) => {
+    // The controls stayed live after a correct answer, so you could still ask
+    // for the choices — or re-submit — on a card you had already won.
+    await reviewOne(page, REF_ITEM);
+
+    await input(page).fill('Joshua 6');
+    await page.getByRole('button', { name: 'Check reference' }).click();
+
+    await expect(page.getByRole('button', { name: 'Check reference' })).toBeHidden();
+    await expect(page.getByRole('button', { name: 'Show me the choices' })).toBeHidden();
+    // What was typed stays on screen, but cannot be edited.
+    await expect(input(page)).toBeDisabled();
+    await expect(input(page)).toHaveValue('Joshua 6');
+  });
+
+  test('the abbreviation from the issue is accepted', async ({ page }) => {
+    await reviewOne(page, REF_ITEM);
+
+    await input(page).fill('Josh 6');
+    await page.keyboard.press('Enter');
+
+    await expect(page.locator('.feedback.correct')).toContainText('Correct');
+  });
+
+  test('a wrong reference costs the bonus but not the question', async ({ page }) => {
+    await reviewOne(page, REF_ITEM);
+
+    await input(page).fill('Joshua 5');
+    await page.getByRole('button', { name: 'Check reference' }).click();
+
+    // Not marked wrong — it falls through to the ordinary multiple choice.
+    await expect(page.locator('.feedback')).toHaveCount(0);
+    await expect(input(page)).toBeHidden();
+    await expect(choices(page)).toHaveCount(4);
+
+    await page.locator('.choice').filter({ has: page.getByText('Joshua 6', { exact: true }) }).click();
+    await expect(page.locator('.feedback.correct')).toContainText('Correct');
+    // Scored normally, so the member grades it themselves.
+    await expect(page.getByRole('button', { name: /^Ok/ })).toBeVisible();
+  });
+
+  test('you can decline the bonus and take the choices', async ({ page }) => {
+    await reviewOne(page, REF_ITEM);
+
+    await page.getByRole('button', { name: 'Show me the choices' }).click();
+
+    await expect(input(page)).toBeHidden();
+    await expect(choices(page)).toHaveCount(4);
+    await expect(page.locator('.feedback')).toHaveCount(0);
+  });
+
+  test('digits typed into the reference box do not pick an option', async ({ page }) => {
+    // The number keys are an answering shortcut for multiple choice. While the
+    // bonus input is up they must stay out of the way, or "1 Cor 15" would
+    // answer the card on its first keystroke.
+    await reviewOne(page, REF_ITEM);
+
+    await input(page).fill('');
+    await page.keyboard.type('1');
+
+    await expect(page.locator('.feedback')).toHaveCount(0);
+    await expect(input(page)).toHaveValue('1');
+  });
+
+  test('a question whose answer is not a reference is unaffected', async ({ page }) => {
+    // gen-position-genesis answers "Exodus" — a book, not a place in it.
+    await reviewOne(page, 'gen-position-genesis');
+
+    await expect(input(page)).toBeHidden();
+    await expect(choices(page)).toHaveCount(4);
+  });
+});

--- a/tests/e2e/reference.spec.ts
+++ b/tests/e2e/reference.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * The reference matcher behind the typed bonus round (#14).
+ *
+ * These run in Node against the real module. The prose matcher used by `type`
+ * questions is deliberately loose — it strips punctuation, drops small words,
+ * and accepts substrings — all of which is wrong for a citation, where the
+ * colon is load-bearing and "Genesis 3" must not answer "Genesis 30". This
+ * pins the behaviour that keeps the two apart.
+ */
+import { expect, test } from '@playwright/test';
+import { isReference, parseReference, referenceMatches } from '../../src/lib/reference';
+
+test.describe('recognising a reference', () => {
+  test('an answer that names a place in scripture earns a typed round', () => {
+    for (const ref of ['Genesis 3', 'Genesis 1-2', 'Josh 6', '1 Cor 15:1-8', 'Song of Solomon 2']) {
+      expect(isReference(ref), ref).toBe(true);
+    }
+  });
+
+  test('an answer that is a fact rather than a place does not', () => {
+    for (const notRef of ['Psalms', 'Exodus', '66', 'Psalm 119 is the longest', 'Nadab and Abihu']) {
+      expect(isReference(notRef), notRef).toBe(false);
+    }
+  });
+});
+
+test.describe('parsing a reference', () => {
+  test('a book is the same book however it is written', () => {
+    expect(parseReference('Joshua 6')?.book).toBe('joshua');
+    expect(parseReference('Josh 6')?.book).toBe('joshua');
+    expect(parseReference('josh 6')?.book).toBe('joshua');
+    expect(parseReference('Josh. 6')?.book).toBe('joshua');
+  });
+
+  test('a numbered book is not confused with its unnumbered namesake', () => {
+    expect(parseReference('1 John 2')?.book).toBe('1-john');
+    expect(parseReference('John 2')?.book).toBe('john');
+    // "Job" must not swallow the front of "John".
+    expect(parseReference('Job 2')?.book).toBe('job');
+  });
+
+  test('spacing and dash style do not change the place', () => {
+    expect(parseReference('1 Cor 15:1-8')?.locus).toBe('15:1-8');
+    expect(parseReference('1 Cor 15 : 1 – 8')?.locus).toBe('15:1-8');
+  });
+
+  test('text that names no known book parses to nothing', () => {
+    expect(parseReference('Hezekiah 3')).toBeNull();
+    expect(parseReference('')).toBeNull();
+  });
+});
+
+test.describe('matching a typed reference', () => {
+  test('the abbreviation the issue asks for is accepted', () => {
+    expect(referenceMatches('Josh 6', 'Joshua 6')).toBe(true);
+    expect(referenceMatches('josh 6', 'Joshua 6')).toBe(true);
+    expect(referenceMatches('Joshua 6', 'Josh 6')).toBe(true);
+  });
+
+  test('a different chapter in the right book is still wrong', () => {
+    expect(referenceMatches('Joshua 5', 'Joshua 6')).toBe(false);
+  });
+
+  test('the right chapter in a different book is wrong', () => {
+    expect(referenceMatches('Judges 6', 'Joshua 6')).toBe(false);
+  });
+
+  test('a chapter is not a prefix of a longer chapter number', () => {
+    // The prose matcher accepts substrings, which would make this pass. A
+    // citation matcher must not: Genesis 3 and Genesis 30 are 27 chapters apart.
+    expect(referenceMatches('Genesis 3', 'Genesis 30')).toBe(false);
+    expect(referenceMatches('Genesis 30', 'Genesis 3')).toBe(false);
+    expect(referenceMatches('1 Cor 1', '1 Cor 15')).toBe(false);
+  });
+
+  test('naming the verse as well as the chapter still counts', () => {
+    // More precision than asked for is more knowledge, not less.
+    expect(referenceMatches('Genesis 3:15', 'Genesis 3')).toBe(true);
+  });
+
+  test('but naming only the chapter does not answer a verse-level question', () => {
+    expect(referenceMatches('Genesis 3', 'Genesis 3:15')).toBe(false);
+  });
+
+  test('one chapter does not answer a span', () => {
+    expect(referenceMatches('Genesis 1', 'Genesis 1-2')).toBe(false);
+    expect(referenceMatches('Genesis 1-2', 'Genesis 1-2')).toBe(true);
+  });
+
+  test('a bare book name locates nothing', () => {
+    expect(referenceMatches('Joshua', 'Joshua 6')).toBe(false);
+    expect(referenceMatches('', 'Joshua 6')).toBe(false);
+  });
+
+  test('the colon survives normalisation', () => {
+    // Stripping punctuation would turn this into chapter 151.
+    expect(referenceMatches('1 Cor 15:1-8', '1 Cor 15:1-8')).toBe(true);
+    expect(referenceMatches('1 Cor 151', '1 Cor 15:1-8')).toBe(false);
+  });
+
+  test('a book whose name contains a dropped word is not mangled', () => {
+    // The prose matcher deletes "of", which would break this book entirely.
+    expect(referenceMatches('Song of Solomon 2', 'Song of Solomon 2')).toBe(true);
+    expect(referenceMatches('Song 2', 'Song of Solomon 2')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #14.

Questions whose answer is a place in scripture — **1,067 of them, ~17% of the bank** — now ask you to name it before showing any options at all.

> **Where does this happen?** *"The walls of Jericho fall after seven days of marching"*
>
> `[ Type the reference, e.g. Josh 6        ]`
> **Check reference**  ·  Show me the choices

The issue's own example, and the choices are genuinely not in the DOM yet.

## The flow

| Path | Result |
|---|---|
| Correct reference | Reveals "Correct" + the explanation, then one **Continue** that files it as **Easy** |
| Wrong reference | Costs the bonus, not the question — one attempt, then the ordinary multiple choice |
| "Show me the choices" | Declines the bonus outright, normal score |
| Non-reference answer | Untouched — no input, four choices as before |

Both scoring decisions were yours: auto-Easy over a bonus counter, and fall-through over counting a wrong guess as a miss.

## Why references get their own matcher

The prose matcher used by `type` questions is actively wrong for citations, and reusing it would have been a quiet correctness bug:

- it strips punctuation, so `1 Cor 15:1-8` becomes **chapter 151**
- it deletes `of`, which mangles **Song of Solomon**
- it accepts substrings either way, so **"Genesis 3" would answer "Genesis 30"**

`src/lib/reference.ts` parses structurally instead — canonical book id, then locus — which gets abbreviations and punctuation tolerance for free and makes `Genesis 1` ≠ `Genesis 1-2` fall out rather than needing a special case.

**Matching is deliberately asymmetric: extra precision passes, missing precision does not.** `Genesis 3:15` answers a question about Genesis 3, because a rule that punished naming the verse would teach people to withhold what they know. `Genesis 3` does not answer `Genesis 3:15`.

## Two things the number-key shortcut forced

`1`-`4` answer a multiple choice. While the bonus input is up they must not reach past it — `options` lives in a `useMemo` whether or not it is rendered, so **"1 Cor 15" would have answered the card on its first keystroke**. And `Enter` had to be wired for an `mcq`, which it never needed before.

## A bug the tests missed and a screenshot caught

My first cut auto-graded the instant you got it right, which advanced the session before you ever saw "Correct" or the explanation — so the reveal now comes first and Continue does the grading.

Then the screenshot showed the input and **both buttons still live after a correct answer** — you could ask for the choices on a card you had already won. Now pinned by `winning the bonus closes the round rather than leaving it open`.

## Interfaces unchanged

`onGrade` keeps its `(g: Grade) => void` signature and `Store` gains nothing. With auto-Easy there is nothing a caller could do differently, so `Review.tsx` and `Quiz.tsx` needed no changes at all.

## Tests

24 new, in two files:

- `reference.spec.ts` (17) — the matcher in Node, including the "Genesis 3" / "Genesis 30" false positive, the surviving colon, and the precision asymmetry
- `bonus-round.spec.ts` (7) — the flow in a browser: options absent until dismissed, auto-Easy on a win, abbreviation accepted, wrong guess falls through, opt-out, digits not hijacked, non-reference questions unaffected

## Verified

- `npx tsc -b` clean
- `npm run validate` — all checks pass
- `npx playwright test --workers=2` — **111 passed**, exit 0, after rebasing onto `main`

Zero existing specs needed changing, exactly as predicted in review — every answering spec pins a single item, and `ITEM.mcq` is `gen-position-genesis`, which is not reference-answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
