### PR TITLE
Use 2 Timothy 2:15 ESV as the motto verse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **The motto verse is 2 Timothy 2:15 ESV** ([#22]). The boot splash now reads
+  *"Do your best to present yourself to God as one approved, a worker who has
+  no need to be ashamed, rightly handling the word of truth."*, quoted in full
+  as the issue gives it, with the citation shown beneath it so the line is
+  never quoted anonymously. Replaces the Hebrews 4:12 epigraph.
+  Worth noting for the record: this is the same verse as the original
+  "Study to shew thyself approved" line that [#5] asked to remove — that was
+  the KJV rendering. The verse is back, in ESV.
+
 - **Question cues name their subject instead of opening on a bare pronoun**
   ([#13]). *Where does this happen? "He reopens and cleanses the temple…"* gave
   you nothing to grip; it now reads *"Hezekiah reopens and cleanses the
@@ -131,6 +140,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   submitted an arrangement without ever checking it, turning the race into a
   confusing count mismatch three assertions later.
 
+[#5]: https://github.com/godwinlaw/scripture-mastery/issues/5
+
 [#7]: https://github.com/godwinlaw/scripture-mastery/issues/7
 
 [#8]: https://github.com/godwinlaw/scripture-mastery/issues/8
@@ -150,3 +161,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [#15]: https://github.com/godwinlaw/scripture-mastery/issues/15
 
 [#16]: https://github.com/godwinlaw/scripture-mastery/issues/16
+
+[#22]: https://github.com/godwinlaw/scripture-mastery/issues/22
+

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -35,8 +35,16 @@ export const copy = {
   },
 
   boot: {
-    // Hebrews 4:12 ESV — the trainer's own charge, not a slogan.
-    epigraph: '“For the word of God is living and active, sharper than any two-edged sword.”',
+    /**
+     * The motto verse (#22). The trainer's own charge: the work is handling
+     * the text rightly, not merely admiring it.
+     *
+     * Quoted in full, as the issue gives it. `mottoRef` is kept alongside so
+     * the line is never shown anonymously — the login screen cites it too.
+     */
+    epigraph:
+      '“Do your best to present yourself to God as one approved, a worker who has no need to be ashamed, rightly handling the word of truth.”',
+    mottoRef: '2 Timothy 2:15 ESV',
     steps: ['Indexing the canon', 'Restoring your progress', 'Queueing today’s review'],
   },
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -728,7 +728,16 @@ dl.facts dd { margin: 0; }
   letter-spacing: 0.26em;
   text-transform: uppercase;
 }
-.boot-splash .epigraph { font-family: var(--font-body); font-style: italic; font-size: 12px; opacity: 0.7; margin-top: 8px; }
+.boot-splash .epigraph { font-family: var(--font-body); font-style: italic; font-size: 12px; opacity: 0.7; margin-top: 8px; line-height: 1.5; text-wrap: pretty; }
+/* The citation sits under the verse, quieter than it and not italic, so the
+   quotation reads as a quotation rather than as more of the sentence. */
+.boot-splash .epigraph-ref {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  opacity: 0.5;
+  margin-top: 6px;
+}
 .boot-splash .rule {
   height: 4px;
   margin: 26px auto 14px;

--- a/src/ui/BootSplash.tsx
+++ b/src/ui/BootSplash.tsx
@@ -23,6 +23,7 @@ export function BootSplash() {
         <Corners />
         <div className="wordmark">{copy.appName}</div>
         <div className="epigraph">{copy.boot.epigraph}</div>
+        <div className="epigraph-ref">{copy.boot.mottoRef}</div>
         <div className="rule" aria-hidden="true">
           <i />
         </div>


### PR DESCRIPTION
Closes #22.

The boot splash epigraph becomes:

> *"Do your best to present yourself to God as one approved, a worker who has no need to be ashamed, rightly handling the word of truth."*
> — 2 Timothy 2:15 ESV

Quoted **in full**, as the issue gives it.

## The citation is new

A verse shown anonymously reads as a slogan; shown with its reference it reads as a quotation, which is what it is. The reference lives in `copy.ts` as `mottoRef` rather than being baked into the splash, because **#23 wants the same verse on the login screen** and it should not be typed twice.

Styled quieter than the verse and not italic, so the citation does not read as more of the sentence.

## One thing worth recording

This is **the same verse** as the "Study to shew thyself approved" line that #5 asked to remove — that was the KJV rendering of 2 Timothy 2:15. So the verse is back, in ESV. Reading the two issues together, the objection was to the wording rather than to the text. Flagging it in case that is not what you intended.

## Layout

The full verse runs to three lines at the splash’s 12px, so the epigraph gains a `line-height` and `text-wrap: pretty` to keep the wrap even. Checked visually, not just by test.

## Verified

- `npx tsc -b` clean
- `npm run validate` — all checks pass
- `npx playwright test --workers=2` — **111 passed**, exit 0. No spec pinned the old verse text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)