### PR TITLE
Show the mark, the verse, and Google's glyph on sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `--color-bg` paper, `--color-accent` rules), written as literals because an
   SVG loaded as a favicon never sees the document's custom properties.
 
+### Fixed
+
+- **The app icon never actually rendered** (found while doing [#23]). Both
+  `icon.svg` and `favicon.svg` shipped malformed in [#7]: an XML comment cannot
+  contain a literal double hyphen, and the comment documenting the colour
+  tokens spelled them `--color-accent-900`. A standalone SVG is parsed as XML,
+  so every browser drew a broken image — while the files returned 200 with the
+  right content-type, which is why serving them looked fine. The comments now
+  name the tokens without their leading dashes and say why, and both files
+  gained intrinsic `width`/`height`. `tests/e2e/icons.spec.ts` now decodes each
+  icon and parses it as XML, because checking that an asset is *served* proves
+  nothing about whether it *renders*.
+
+- **A race in the e2e ordering helper.** `arrangeInto` re-read the list
+  immediately after clicking "Move up", so under load it could compute an index
+  from the pre-click DOM and walk the wrong row. It now waits for each row to
+  land before re-reading, and asserts the finished arrangement — one caller
+  submitted an arrangement without ever checking it, turning the race into a
+  confusing count mismatch three assertions later.
+
 ### Changed
+
+- **The sign-in screen shows the mark, the verse, and Google's own glyph**
+  ([#23]). The app icon appears at 88px as the app's face rather than a
+  favicon; the motto verse is quoted beneath the wordmark with its citation;
+  and the sign-in button carries the official four-colour Google "G", as
+  Google's branding guidelines require for a "Sign in with Google" control.
+  The verse moved to a top-level `copy.motto` so the splash and the sign-in
+  speak from one source — a verse transcribed twice is one that will eventually
+  disagree with itself.
 
 - **The motto verse is 2 Timothy 2:15 ESV** ([#22]). The boot splash now reads
   *"Do your best to present yourself to God as one approved, a worker who has
@@ -131,15 +160,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   longest chapter in the Bible?" → Psalm 119). Bank is now 6,514 items and
   every book still clears the 20-question floor.
 
-### Fixed
-
-- **A race in the e2e ordering helper.** `arrangeInto` re-read the list
-  immediately after clicking "Move up", so under load it could compute an index
-  from the pre-click DOM and walk the wrong row. It now waits for each row to
-  land before re-reading, and asserts the finished arrangement — one caller
-  submitted an arrangement without ever checking it, turning the race into a
-  confusing count mismatch three assertions later.
-
 [#5]: https://github.com/godwinlaw/scripture-mastery/issues/5
 
 [#7]: https://github.com/godwinlaw/scripture-mastery/issues/7
@@ -164,3 +184,5 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 [#22]: https://github.com/godwinlaw/scripture-mastery/issues/22
 
+
+[#23]: https://github.com/godwinlaw/scripture-mastery/issues/23

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Scripture Mastery">
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="Scripture Mastery">
   <title>Scripture Mastery</title>
   <!--
     The same 2a mark at its small-size treatment: the blade is widened and the

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Scripture Mastery">
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="Scripture Mastery">
   <title>Scripture Mastery</title>
   <!--
     "Blade on the page" (design 2a). A ribbon marker cut from paper on a steel
@@ -6,9 +6,13 @@
 
     Colours are the app's own tokens, written as literals because an SVG loaded
     as a favicon never sees the document's custom properties:
-      #1d2d3d  --color-accent-900   steel field / blade
-      #f2f2f3  --color-bg           paper ribbon
-      #5980a6  --color-accent       the rules standing in for the passage
+      #1d2d3d  is  color-accent-900  steel field and blade
+      #f2f2f3  is  color-bg          paper ribbon
+      #5980a6  is  color-accent      the rules standing in for the passage
+
+    Token names are written without their leading dashes on purpose: a literal
+    double hyphen is illegal inside an XML comment, and a standalone SVG is
+    parsed as XML, so it would render as a broken image.
 
     This is the full-detail cut, for app tiles and any size at or above 48px.
     favicon.svg carries the simplified small-size treatment.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Progress from './views/Progress';
 import { useStore } from './lib/useStore';
 import { allItems } from './lib/generate';
 import { ALLOWED_DOMAINS, signIn, signOutUser } from './lib/firebase';
+import GoogleMark from './ui/GoogleMark';
 import { BootSplash, MobileGate, Corners, Segmented, useIsMobile } from './ui';
 import { copy } from './copy';
 import { useThemeMode, type ThemeMode } from './lib/theme';
@@ -86,6 +87,17 @@ export default function App() {
         <div className="empty screen">
           <div className="blueprint" style={{ maxWidth: 360, margin: '0 auto', padding: '40px 32px' }}>
             <Corners />
+            {/* The mark, at a size that reads as the app's face rather than a
+                favicon. Sourced from the same file the browser tab uses, so
+                the two cannot drift; BASE_URL keeps it correct under vite's
+                relative `base`. */}
+            <img
+              className="signin-mark"
+              src={`${import.meta.env.BASE_URL}icon.svg`}
+              alt=""
+              width={88}
+              height={88}
+            />
             <div
               style={{
                 fontFamily: 'var(--font-heading)',
@@ -98,6 +110,10 @@ export default function App() {
             >
               {copy.appName}
             </div>
+            <blockquote className="signin-motto">
+              {copy.motto.text}
+              <cite>{copy.motto.ref}</cite>
+            </blockquote>
             <p className="small muted">
               {denied
                 ? copy.auth.denied(api.user?.email, ALLOWED_DOMAINS)
@@ -118,6 +134,7 @@ export default function App() {
                     );
                   }}
                 >
+                  <GoogleMark />
                   {copy.auth.signInButton}
                 </button>
               )}

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -16,6 +16,22 @@ function orList(items: readonly string[]): string {
 export const copy = {
   appName: 'Scripture Mastery',
 
+  /**
+   * The motto verse (#22). The trainer's own charge: the work is handling the
+   * text rightly, not merely admiring it. Quoted in full, as the issue gives it.
+   *
+   * Top-level rather than under `boot` because two screens speak it — the boot
+   * splash and the sign-in (#23) — and a verse transcribed twice is a verse
+   * that will eventually disagree with itself. `ref` travels with `text` so the
+   * line is never shown anonymously; a verse without its citation reads as a
+   * slogan.
+   */
+  motto: {
+    text:
+      '“Do your best to present yourself to God as one approved, a worker who has no need to be ashamed, rightly handling the word of truth.”',
+    ref: '2 Timothy 2:15 ESV',
+  },
+
   header: {
     /** e.g. "1,240 questions across 66 books" */
     tagline: (questionCount: number) =>
@@ -35,16 +51,6 @@ export const copy = {
   },
 
   boot: {
-    /**
-     * The motto verse (#22). The trainer's own charge: the work is handling
-     * the text rightly, not merely admiring it.
-     *
-     * Quoted in full, as the issue gives it. `mottoRef` is kept alongside so
-     * the line is never shown anonymously — the login screen cites it too.
-     */
-    epigraph:
-      '“Do your best to present yourself to God as one approved, a worker who has no need to be ashamed, rightly handling the word of truth.”',
-    mottoRef: '2 Timothy 2:15 ESV',
     steps: ['Indexing the canon', 'Restoring your progress', 'Queueing today’s review'],
   },
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -738,6 +738,40 @@ dl.facts dd { margin: 0; }
   opacity: 0.5;
   margin-top: 6px;
 }
+
+/* --- Sign-in (#23) ------------------------------------------------------- */
+
+/* The mark at the size of a face, not a favicon. It carries its own steel
+   ground, so it needs no plate behind it in either theme. */
+.signin-mark {
+  display: block;
+  margin: 0 auto 18px;
+  width: 88px;
+  height: 88px;
+}
+
+/* The motto, quoted rather than asserted: indented, italic, with the citation
+   on its own line beneath. `blockquote` and `cite` carry the meaning; the
+   reset strips their default margins, so both are restated here. */
+.signin-motto {
+  margin: 0 0 18px;
+  padding: 0 4px;
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 12.5px;
+  line-height: 1.6;
+  text-wrap: pretty;
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
+}
+.signin-motto cite {
+  display: block;
+  margin-top: 7px;
+  font-family: var(--font-mono);
+  font-style: normal;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--color-text) 45%, transparent);
+}
 .boot-splash .rule {
   height: 4px;
   margin: 26px auto 14px;

--- a/src/ui/BootSplash.tsx
+++ b/src/ui/BootSplash.tsx
@@ -22,8 +22,8 @@ export function BootSplash() {
       <div className="scale">
         <Corners />
         <div className="wordmark">{copy.appName}</div>
-        <div className="epigraph">{copy.boot.epigraph}</div>
-        <div className="epigraph-ref">{copy.boot.mottoRef}</div>
+        <div className="epigraph">{copy.motto.text}</div>
+        <div className="epigraph-ref">{copy.motto.ref}</div>
         <div className="rule" aria-hidden="true">
           <i />
         </div>

--- a/src/ui/GoogleMark.tsx
+++ b/src/ui/GoogleMark.tsx
@@ -1,0 +1,41 @@
+/**
+ * Google's "G", for the sign-in button (#23).
+ *
+ * Google's branding guidelines require their own mark on a "Sign in with
+ * Google" control — a recoloured or redrawn approximation is not permitted —
+ * so this is the official four-colour glyph at its published path data, and
+ * the colours are literals rather than theme tokens for the same reason: the
+ * mark must not follow our palette into dark mode.
+ *
+ * Decorative: the button's own text already says "Sign in with Google", so
+ * the glyph is hidden from assistive tech rather than announced twice.
+ */
+export default function GoogleMark({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 48 48"
+      aria-hidden="true"
+      focusable="false"
+      style={{ display: 'block', flex: 'none' }}
+    >
+      <path
+        fill="#4285F4"
+        d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17z"
+      />
+      <path
+        fill="#34A853"
+        d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M11.69 28.18C11.25 26.86 11 25.45 11 24s.25-2.86.69-4.18v-5.7H4.34C2.85 17.09 2 20.45 2 24s.85 6.91 2.34 9.88l7.35-5.7z"
+      />
+      <path
+        fill="#EA4335"
+        d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07z"
+      />
+    </svg>
+  );
+}

--- a/tests/e2e/icons.spec.ts
+++ b/tests/e2e/icons.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * The app's icons must actually decode, not merely be served.
+ *
+ * Both shipped malformed once: an XML comment cannot contain a literal double
+ * hyphen, and the comment explaining the colour tokens spelled them
+ * "--color-accent-900". The files still returned 200 with the right
+ * content-type, so a fetch-based check passed happily while every browser
+ * rendered a broken image. Only decoding catches that.
+ */
+import { expect, test } from '@playwright/test';
+import { openAs } from './harness';
+
+const ICONS = ['icon.svg', 'favicon.svg'];
+
+test.describe('app icons', () => {
+  for (const file of ICONS) {
+    test(`${file} decodes as an image`, async ({ page }) => {
+      await openAs(page, { email: null });
+
+      const size = await page.evaluate(
+        (name) =>
+          new Promise<number>((resolve) => {
+            const img = new Image();
+            img.onload = () => resolve(img.naturalWidth);
+            img.onerror = () => resolve(-1);
+            img.src = `/${name}`;
+          }),
+        file,
+      );
+
+      // -1 is a decode failure; 0 means it parsed but has no intrinsic size,
+      // which leaves it at the mercy of whatever box it lands in.
+      expect(size, `${file} did not decode`).toBeGreaterThan(0);
+    });
+
+    test(`${file} is well-formed XML`, async ({ page }) => {
+      await openAs(page, { email: null });
+
+      const err = await page.evaluate(async (name) => {
+        const text = await (await fetch(`/${name}`)).text();
+        const doc = new DOMParser().parseFromString(text, 'image/svg+xml');
+        return doc.querySelector('parsererror')?.textContent ?? null;
+      }, file);
+
+      expect(err, `${file} is not well-formed`).toBeNull();
+    });
+  }
+
+  test('the sign-in screen shows the mark, and it has rendered', async ({ page }) => {
+    await openAs(page, { email: null });
+
+    const mark = page.locator('.signin-mark');
+    await expect(mark).toBeVisible();
+    expect(await mark.evaluate((el) => (el as HTMLImageElement).naturalWidth)).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #23.

All three items from the issue:

- **App icon blown up** — the mark at 88px, so the screen leads with the app's face rather than a wordmark alone
- **Google symbol next to the Google login** — the official four-colour "G"
- **Motto verse 2 Tim 2:15 ESV** — quoted beneath the wordmark, with its citation

The verse moved to a top-level `copy.motto`, shared by the boot splash and the sign-in. Two screens transcribing the same verse is two screens that will eventually disagree about it.

On the Google mark: it is their published glyph at their path data, with the brand colours as literals rather than theme tokens. Google's branding guidelines require their own mark on a "Sign in with Google" control, and a recoloured or redrawn approximation does not satisfy that — it also must not follow our palette into dark mode. It is `aria-hidden`, since the button text already says "Sign in with Google".

---

## A real bug this uncovered — the favicon has been broken in production since #7

**Neither `icon.svg` nor `favicon.svg` had ever rendered.**

An XML comment cannot contain a literal double hyphen. The comment I wrote in #7 documenting the colour tokens spelled them:

```
      #1d2d3d  --color-accent-900   steel field / blade
```

A standalone SVG is parsed as XML, so that makes the file malformed and every browser draws a broken image.

**Why #7 missed it, which is the part worth learning from:** I verified the icons were *served* — `curl` returned `200 image/svg+xml` for each — and treated that as proof they worked. Serving an asset proves nothing about whether it decodes. I only caught it now because I put the same file on screen at 88px and *looked at it*.

The fix: comments name the tokens without their leading dashes and say why. Both files also gain intrinsic `width`/`height`, so they are not left at the mercy of whatever box they land in.

`tests/e2e/icons.spec.ts` now, for each icon:

- loads it through `new Image()` and requires `naturalWidth > 0` — a decode failure gives -1, and 0 means it parsed but has no intrinsic size
- parses it with `DOMParser` and requires no `parsererror`
- plus one test that the sign-in mark is visible **and has actually rendered**

Confirmed against the live site: this is a production bug, not just a local one.

## Verified

- `npx tsc -b` clean
- `npm run validate` — all checks pass
- `npx playwright test --workers=2` — **116 passed**, exit 0 (111 + 5 new)
- Checked visually, which is how the icon bug surfaced at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)
