### PR TITLE
Show the app mark in the top bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **The app mark now sits in the top bar** ([#34]). The header carried the
+  wordmark alone, so the mark that identifies the app on the browser tab, on
+  the sign-in screen and on an installed tile was missing from the one surface
+  you look at all day. It uses `favicon.svg` rather than the `icon.svg` the
+  sign-in screen shows: that is the mark's small-size cut, with the blade
+  widened and the passage rules dropped, drawn for exactly this 16–24px range
+  — `icon.svg`'s fine detail would turn to mush at 22px. Referenced through
+  `import.meta.env.BASE_URL`, as the sign-in mark already is, because vite's
+  `base` is relative and a root-absolute path would break anywhere the app is
+  not served from `/`. The image is decorative (`alt=""`): the wordmark sits
+  immediately beside it, so naming it would only make a screen reader say
+  "Scripture Mastery" twice.
+
 - **Type the reference for a bonus** ([#14]). Questions whose answer is a place
   in scripture — 1,067 of them, about 17% of the bank — now ask you to name it
   before showing any options at all. *Where does this happen? "The walls of
@@ -186,3 +199,5 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
 [#23]: https://github.com/godwinlaw/scripture-mastery/issues/23
+
+[#34]: https://github.com/godwinlaw/scripture-mastery/issues/34

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,6 +159,16 @@ export default function App() {
     <div className="app">
       <header className="top">
         <div className="brand">
+          {/* favicon.svg, not the icon.svg the sign-in screen uses: this is the
+              mark's small-size cut, drawn for exactly this range. BASE_URL for
+              the same reason as there — vite's base is relative. */}
+          <img
+            className="brand-mark"
+            src={`${import.meta.env.BASE_URL}favicon.svg`}
+            alt=""
+            width={22}
+            height={22}
+          />
           {copy.appName}
           <span>{copy.header.tagline(total)}</span>
         </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -222,6 +222,15 @@ header.top,
   align-items: baseline;
   gap: 12px;
 }
+.brand-mark {
+  /* .brand aligns its children on the baseline, which an image has no useful
+     notion of — it would sit on its bottom edge. Centre it against the
+     wordmark instead. */
+  width: 22px;
+  height: 22px;
+  align-self: center;
+  flex: none;
+}
 .brand span {
   font-family: var(--font-body);
   color: color-mix(in srgb, var(--color-text) 50%, transparent);

--- a/tests/e2e/shell.spec.ts
+++ b/tests/e2e/shell.spec.ts
@@ -50,6 +50,23 @@ test.describe('shell and auth', () => {
     await expect(page.getByRole('navigation')).toBeVisible();
   });
 
+  test('the header shows the app mark beside the wordmark', async ({ page }) => {
+    await openAs(page);
+
+    const mark = page.locator('header .brand .brand-mark');
+    await expect(mark).toBeVisible();
+
+    // A missing image still counts as "visible", so check it actually decoded —
+    // that is what would catch the asset path going stale.
+    await expect
+      .poll(() => mark.evaluate((el) => (el as HTMLImageElement).naturalWidth))
+      .toBeGreaterThan(0);
+
+    // Decorative on purpose: the wordmark sits immediately beside it, so giving
+    // the image a name would just make a screen reader say it twice.
+    await expect(mark).toHaveAttribute('alt', '');
+  });
+
   test('the header counts down to the seeded quiz date', async ({ page }) => {
     await openAs(page, { store: { settings: { examDate: '2027-03-04', newLimit: 20, sessionLimit: 60 } } });
 


### PR DESCRIPTION
Closes #34.

The header carried the wordmark alone, so the mark that identifies the app on the browser tab, on the sign-in screen and on an installed tile was missing from the one surface you look at all day.

## Which cut of the mark

`favicon.svg`, not the `icon.svg` the sign-in screen shows at 88px. That is the mark's small-size treatment — blade widened, passage rules dropped — drawn for exactly this 16–24px range, and its own file comment says so. `icon.svg`'s fine detail would turn to mush at 22px.

## One latent bug avoided

Referenced through `import.meta.env.BASE_URL`, as the sign-in mark already is, because vite's `base` is `'./'`. A root-absolute `/favicon.svg` would break anywhere the app is not served from `/` — and no test would have caught it, since dev and E2E both serve from the root.

## Accessibility

Decorative, `alt=""`: the wordmark sits immediately beside it, so naming the image would only make a screen reader say "Scripture Mastery" twice. The a11y tree confirms it is skipped.

`.brand` aligns its children on the baseline, which an image has no useful notion of — it would sit on its bottom edge — so the mark centres against the wordmark instead.

## Test plan

- New `shell.spec.ts` case asserts the mark renders, **actually decodes** (`naturalWidth > 0`, so a stale asset path fails rather than passing as an invisible broken image), and stays decorative. Verified it fails when the path is broken.
- `npm run check` — clean
- `npm run validate` — all content checks pass
- `npm run test:e2e --workers=2` (CI's concurrency) — 117/117 green
- Eyeballed in both themes: the steel tile holds against the light paper header and the near-black dark one.