### PR TITLE
Add a Settings panel with a difficulty setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **A Settings panel, and a difficulty you can choose** ([#36]). Settings had
+  been scattered — the study fields inside Progress, the theme switch in the
+  header, the quiz date in two places — so there was no one screen to go to.
+  There is now: a **Settings** tab holding Study, Difficulty and Display.
+
+  **Difficulty decides where a question's wrong answers come from.** *Medium*
+  is what the trainer has always done and remains the default, so nothing
+  changes unless you ask it to: options are drawn from books near the answer's
+  own, never crossing the Old/New Testament seam ([#10], [#12]). *Easy* draws
+  from anywhere in the canon — a Colossians verse against a Leviticus question
+  is not a hard choice, which is the point. *Hard* draws Chapter Content
+  options from the answer's **own book** only, so nothing is given away by
+  context, and Events options from its own division.
+
+  Where a strict pool cannot fill four options it widens a division at a time
+  rather than offering three, because a three-choice question is *easier* than
+  a four-choice one — falling short would invert the setting instead of
+  sharpening it. All three option sets are generated up front and stored on the
+  item, rather than rebuilding the bank when the setting changes: item ids are
+  what SRS history is keyed on, so a bank that regenerated per difficulty would
+  detach every card you have ever reviewed the moment you touched the control.
+
+  Difficulty also leans the review queue, using the per-card ease the scheduler
+  already tracks — *hard* spends its time on what you keep missing, *easy* on
+  what you answer well. The lean shifts a card's effective due date by at most
+  a few days, so it reorders cards of similar urgency without ever letting a
+  badly overdue one slip. Selection still runs before the session cut, and the
+  order questions are asked in is still random ([#11]).
+
+  Verified across the whole bank: of the Chapter Content and Events questions,
+  **zero** medium or hard options cross the Testament seam, easy ones
+  deliberately do, and no alternate set is thinner than the medium one. The
+  content-integrity checks now cover the easy and hard sets too — previously
+  they only ever inspected the default one, so a leaked answer would have
+  shipped invisibly to anyone who had moved off it.
+
 - **The app mark now sits in the top bar** ([#34]). The header carried the
   wordmark alone, so the mark that identifies the app on the browser tab, on
   the sign-in screen and on an installed tile was missing from the one surface
@@ -201,3 +237,5 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [#23]: https://github.com/godwinlaw/scripture-mastery/issues/23
 
 [#34]: https://github.com/godwinlaw/scripture-mastery/issues/34
+
+[#36]: https://github.com/godwinlaw/scripture-mastery/issues/36

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -12,7 +12,7 @@ import { ESSENTIALS, ESSENTIAL_ALIASES, ESSENTIAL_ENTRY_COUNT } from '../src/dat
 import { LISTS } from '../src/data/extras';
 import { ESSENTIAL_ITEM_IDS } from '../src/lib/generate-essentials';
 import { TOPIC_LABELS } from '../src/data/types';
-import type { Item } from '../src/data/types';
+import type { Difficulty, Item } from '../src/data/types';
 import { allItems } from '../src/lib/generate';
 
 const items = allItems();
@@ -34,6 +34,19 @@ hard('items with an empty prompt or answer', items.filter((i) => !i.prompt.trim(
 hard('mcq items with fewer than 3 distractors', items.filter((i) => i.kind === 'mcq' && (i.distractors?.length ?? 0) < 3), (i: Item) => i.id);
 hard('mcq items whose answer is also a distractor', items.filter((i) => i.distractors?.includes(i.answer)), (i: Item) => `${i.id} | ${i.prompt}`);
 hard('mcq items with duplicate distractors', items.filter((i) => i.distractors && dupes(i.distractors).length > 0), (i: Item) => i.id);
+// The easy and hard option sets (#36) are generated content in exactly the way
+// the medium set is, and the card swaps one in wholesale at render. The three
+// gates above only ever look at `distractors`, so a leaked answer or a short
+// pool in an alternate set would ship invisibly — to anyone who had moved off
+// the default setting, which is the whole point of having it.
+(['easy', 'hard'] as Difficulty[]).forEach((level) => {
+  const withSet = items.filter((i) => i.distractorsBy?.[level]);
+  const optionsOf = (i: Item) => i.distractorsBy![level]!;
+  hard(`mcq items with fewer than 3 ${level} distractors`, withSet.filter((i) => optionsOf(i).length < 3), (i: Item) => i.id);
+  hard(`mcq items whose answer is also a ${level} distractor`, withSet.filter((i) => optionsOf(i).includes(i.answer)), (i: Item) => `${i.id} | ${i.prompt}`);
+  hard(`mcq items with duplicate ${level} distractors`, withSet.filter((i) => dupes(optionsOf(i)).length > 0), (i: Item) => i.id);
+});
+
 hard('order items with a duplicated step', items.filter((i) => i.kind === 'order' && i.sequence && dupes(i.sequence).length > 0), (i: Item) => i.id);
 hard('order items with fewer than 3 steps', items.filter((i) => i.kind === 'order' && (i.sequence?.length ?? 0) < 3), (i: Item) => i.id);
 hard('items pointing at a book that does not exist', items.filter((i) => i.book && !BOOKS.some((b) => b.id === i.book)), (i: Item) => `${i.id} -> ${i.book}`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,13 +5,13 @@ import Quiz from './views/Quiz';
 import Library from './views/Library';
 import Plan from './views/Plan';
 import Progress from './views/Progress';
+import Settings from './views/Settings';
 import { useStore } from './lib/useStore';
 import { allItems } from './lib/generate';
 import { ALLOWED_DOMAINS, signIn, signOutUser } from './lib/firebase';
 import GoogleMark from './ui/GoogleMark';
-import { BootSplash, MobileGate, Corners, Segmented, useIsMobile } from './ui';
+import { BootSplash, MobileGate, Corners, useIsMobile } from './ui';
 import { copy } from './copy';
-import { useThemeMode, type ThemeMode } from './lib/theme';
 
 const TABS = [
   { id: 'home', label: 'Dashboard' },
@@ -20,16 +20,10 @@ const TABS = [
   { id: 'library', label: 'Reference' },
   { id: 'plan', label: 'Study Plan' },
   { id: 'progress', label: 'Progress' },
+  { id: 'settings', label: 'Settings' },
 ] as const;
 
 type TabId = (typeof TABS)[number]['id'];
-
-/** Light default, then Dark, then follow-the-OS System. */
-const THEME_OPTIONS: { label: string; value: ThemeMode }[] = [
-  { label: copy.theme.light, value: 'light' },
-  { label: copy.theme.dark, value: 'dark' },
-  { label: copy.theme.system, value: 'system' },
-];
 
 /** How long the boot mark stays up at minimum, so it reads as a screen and not
  *  a flicker. Never blocks past a genuine load that outlasts it. */
@@ -46,7 +40,6 @@ export default function App() {
   const [tab, setTab] = useState<TabId>(currentHash);
   const [authError, setAuthError] = useState('');
   const [splashHeld, setSplashHeld] = useState(true);
-  const [themeMode, setTheme] = useThemeMode();
 
   useEffect(() => {
     const onHash = () => setTab(currentHash());
@@ -177,13 +170,8 @@ export default function App() {
             <strong>{api.daysLeft.toLocaleString()}</strong> day{api.daysLeft === 1 ? '' : 's'} until{' '}
             {examDateLabel}
           </div>
-          <Segmented
-            className="theme-seg"
-            ariaLabel={copy.theme.label}
-            options={THEME_OPTIONS}
-            value={themeMode}
-            onChange={setTheme}
-          />
+          {/* The theme switch used to sit here; it moved into the Settings
+              panel with the rest of the preferences (#36). */}
           <button className="btn sm" title={api.user?.email ?? ''} onClick={() => signOutUser()}>
             {copy.header.signOut}
           </button>
@@ -209,6 +197,7 @@ export default function App() {
         {tab === 'library' && <Library />}
         {tab === 'plan' && <Plan api={api} />}
         {tab === 'progress' && <Progress api={api} />}
+        {tab === 'settings' && <Settings api={api} />}
       </main>
     </div>
   );

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { TOPIC_LABELS, type Item } from '../data/types';
+import { TOPIC_LABELS, type Difficulty, type Item } from '../data/types';
 import type { Grade } from '../lib/srs';
 import { shuffle } from '../lib/rng';
 import { isReference, referenceMatches } from '../lib/reference';
@@ -11,6 +11,8 @@ interface Props {
   onToggleStar?: () => void;
   /** Shown top-right, e.g. "12 / 40". */
   counter?: string;
+  /** Which of the item's option sets to offer (#36). Omitted means medium. */
+  difficulty?: Difficulty;
 }
 
 /** Loose comparison so "3 days" and "three days" both count. */
@@ -39,7 +41,7 @@ function matches(input: string, item: Item): boolean {
   return targets.some((t) => t === got || (t.length > 4 && got.length > 4 && (t.includes(got) || got.includes(t))));
 }
 
-export default function QuestionCard({ item, onGrade, starred, onToggleStar, counter }: Props) {
+export default function QuestionCard({ item, onGrade, starred, onToggleStar, counter, difficulty }: Props) {
   const [picked, setPicked] = useState<string | null>(null);
   const [typed, setTyped] = useState('');
   const [revealed, setRevealed] = useState(false);
@@ -59,10 +61,20 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
   /** Named the reference unprompted — the card grades itself Easy on advance. */
   const [bonusEarned, setBonusEarned] = useState(false);
 
+  /**
+   * The setting chooses which of the item's option sets is offered (#36).
+   *
+   * `medium` has no entry of its own — it *is* `distractors` — and plenty of
+   * items carry no alternates at all, because the essentials lists and the
+   * hand-written extras draw their options from somewhere other than the
+   * canon. Both cases land on the same fallback.
+   */
+  const wrong = item.distractorsBy?.[difficulty ?? 'medium'] ?? item.distractors ?? [];
+
   const options = useMemo(
-    () => (item.kind === 'mcq' ? shuffle([item.answer, ...(item.distractors ?? [])]) : []),
+    () => (item.kind === 'mcq' ? shuffle([item.answer, ...wrong]) : []),
     // Reshuffle per item so the answer is not always in the same slot.
-    [item.id],
+    [item.id, difficulty],
   );
 
   useEffect(() => {

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -50,6 +50,56 @@ export const copy = {
     system: 'System',
   },
 
+  /**
+   * The settings panel (#36).
+   *
+   * Difficulty is the reason this copy has to work hard: "Easy / Medium / Hard"
+   * says nothing about *what* changes, and what changes here is where a
+   * question's wrong options are drawn from. So every level carries a sentence
+   * describing the mechanism, and all three stay on screen at once — a reader
+   * choosing between them needs to compare them, not discover them one at a
+   * time.
+   */
+  settings: {
+    display: {
+      heading: 'Display',
+      help: 'Kept on this device, not in your account — so a shared computer never changes how the app looks on your own.',
+      themeCaption: 'Theme',
+      themeNote: 'Light by default. System follows whatever your computer is set to.',
+    },
+
+    difficulty: {
+      heading: 'Difficulty',
+      /** accessible name for the Easy/Medium/Hard switch */
+      label: 'Default difficulty',
+      help: 'Difficulty decides where a question’s wrong answers come from, and which cards the review queue puts in front of you. It takes effect on the next question you see.',
+      options: {
+        easy: {
+          label: 'Easy',
+          note: 'Wrong answers can be drawn from anywhere in the canon, so the right one usually stands out on sight. The queue keeps bringing back the cards you already answer well.',
+        },
+        medium: {
+          label: 'Medium',
+          note: 'Wrong answers come from books near the answer’s own, and never cross between the Old and New Testaments. This is how the trainer has always worked.',
+        },
+        hard: {
+          label: 'Hard',
+          note: 'Wrong answers come only from the same book, so nothing is given away by context. The queue spends most of its time on whatever you keep missing.',
+        },
+      },
+    },
+
+    study: {
+      heading: 'Study',
+      help: 'The date everything is scheduled against, and how much the trainer puts in front of you in one sitting.',
+      examDate: 'Quiz date',
+      newLimit: 'New cards per session',
+      sessionLimit: 'Max cards per session',
+      clampNote:
+        'Review intervals are capped so no card is scheduled past your quiz date without one more look at it.',
+    },
+  },
+
   boot: {
     steps: ['Indexing the canon', 'Restoring your progress', 'Queueing today’s review'],
   },

--- a/src/data/books.ts
+++ b/src/data/books.ts
@@ -1208,6 +1208,19 @@ export function nearbyPool(
 }
 
 /**
+ * Every candidate in the canon, both Testaments, with no regard for where the
+ * question came from — the one pool that is allowed to cross the seam.
+ *
+ * This exists for the `easy` setting alone (#36). Offering a Pauline epistle
+ * against a question about Leviticus is precisely the mismatch the widening
+ * rule above was written to prevent, and precisely what makes an easy card
+ * easy: the wrong options are wrong on sight.
+ */
+export function canonPool(extract: (b: Book) => string[], answer: string): string[] {
+  return [...new Set(BOOKS.flatMap(extract))].filter((s) => s !== answer);
+}
+
+/**
  * The prophets are the one stretch of the canon where a book's summary is the
  * thing worth knowing: seventeen books with overlapping vocabulary, and no
  * narrative spine to hang them on, so "which book is this?" is a real question

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -47,6 +47,18 @@ export interface Book {
   hook?: string;
 }
 
+/**
+ * How tightly wrong options are drawn, and which cards the review queue
+ * favours (#36).
+ *
+ * `medium` is what the app has always done — options from the answer's own
+ * division, widening outward, never crossing the Old/New Testament seam — so
+ * it is the default and an existing user sees no change.
+ */
+export type Difficulty = 'easy' | 'medium' | 'hard';
+
+export const DIFFICULTIES: readonly Difficulty[] = ['easy', 'medium', 'hard'];
+
 export type QuestionKind =
   | 'mcq'      // pick one of four
   | 'type'     // type the answer
@@ -63,6 +75,17 @@ export interface Item {
   answer: string;
   /** Wrong options for mcq. Generated pools keep these plausible. */
   distractors?: string[];
+  /**
+   * Alternate option sets for the easy and hard settings (#36).
+   *
+   * All three sets are baked in at generation rather than regenerating the
+   * bank when the setting changes, because `id` has to stay stable — SRS
+   * history is keyed on it, so a bank that regenerated per difficulty would
+   * detach every card the moment someone toggled the control. Keeping
+   * `distractors` as the medium set also means every existing reader keeps
+   * working untouched; only the render site consults this.
+   */
+  distractorsBy?: Partial<Record<Difficulty, string[]>>;
   /** For 'order' questions: the correct sequence. */
   sequence?: string[];
   /** Accepted alternate spellings for 'type' questions. */

--- a/src/lib/distractors.ts
+++ b/src/lib/distractors.ts
@@ -1,0 +1,92 @@
+/**
+ * One question, three sets of wrong options — one per difficulty setting (#36).
+ *
+ * The sets are computed here, once, at generation time and baked onto the item,
+ * rather than regenerating the bank when the setting changes. Item ids have to
+ * stay byte-identical because SRS history is keyed on them, so a bank that
+ * varied with the setting would detach every card the moment someone touched
+ * the control. Generation stays difficulty-blind; only the render site chooses.
+ *
+ * The `medium` set is whatever the app produced before this file existed, and
+ * it is still what lands in `Item.distractors`, so every existing reader —
+ * validate.ts, the content-contract tests, the quiz results table — is
+ * untouched.
+ */
+import { BOOKS_BY_ID, canonPool, nearbyPool } from '../data/books';
+import type { Book, Difficulty } from '../data/types';
+import { pickDistractors } from './rng';
+
+/**
+ * How tight `hard` is allowed to be for this question.
+ *
+ * Chapter Content asks about the inside of one book, so its wrong options can
+ * come from that same book and still be answerable. High-level Events questions
+ * ("in which book does this happen?") have no inside to draw from — the answer
+ * *is* a book — so the tightest honest pool there is the surrounding division.
+ */
+export type HardScope = 'book' | 'division';
+
+export interface DistractorSets {
+  /** The medium set, unchanged from what the app has always generated. */
+  distractors: string[];
+  /** The easy and hard alternates. Medium is omitted — it is `distractors`. */
+  distractorsBy: Partial<Record<Difficulty, string[]>>;
+}
+
+/**
+ * The pool `hard` draws from: as close to the answer as it can get while still
+ * filling the card.
+ *
+ * The widening matters more than the tightness. A pool that cannot supply `n`
+ * distinct options leaves a question with three choices instead of four, and a
+ * three-choice question is *easier* — which would invert the entire setting.
+ * So when the strict pool comes up short we fall back to the same ring-by-ring
+ * widening `medium` uses: own division first, one division further out per
+ * step, and never across the Testament seam.
+ */
+function hardPool(
+  bookId: string,
+  extract: (b: Book) => string[],
+  answer: string,
+  n: number,
+  scope: HardScope,
+): string[] {
+  if (scope === 'book') {
+    const own = BOOKS_BY_ID[bookId];
+    const inside = own ? [...new Set(extract(own))].filter((s) => s !== answer) : [];
+    if (inside.length >= n) return inside;
+  }
+  // Division scope starts here anyway: nearbyPool's first ring is booksNear(id, 0),
+  // the book's own division, and it widens only when that cannot fill the card.
+  return nearbyPool(bookId, extract, answer, n);
+}
+
+/**
+ * Build all three option sets for one question.
+ *
+ * `extract` pulls candidate strings out of a book, exactly as `nearbyPool`
+ * expects, and it is where any per-question exclusion belongs — books that also
+ * record the event return `[]` — so that the widening counts only books it can
+ * actually offer. Filtering after the pool is built would let a division look
+ * full, stop widening, and then come up short (#12).
+ *
+ * Each set gets its own seed suffix. Without that, a wider pool reshuffled by
+ * the same seed lands on nearly the same handful of strings and easy, medium
+ * and hard become three names for one question.
+ */
+export function distractorSets(
+  bookId: string,
+  extract: (b: Book) => string[],
+  answer: string,
+  seed: string,
+  hardScope: HardScope,
+  n = 3,
+): DistractorSets {
+  return {
+    distractors: pickDistractors(nearbyPool(bookId, extract, answer, n), answer, n, seed),
+    distractorsBy: {
+      easy: pickDistractors(canonPool(extract, answer), answer, n, `${seed}:easy`),
+      hard: pickDistractors(hardPool(bookId, extract, answer, n, hardScope), answer, n, `${seed}:hard`),
+    },
+  };
+}

--- a/src/lib/generate-detail.ts
+++ b/src/lib/generate-detail.ts
@@ -1,6 +1,7 @@
-import { BOOKS, isPropheticBook, nearbyPool } from '../data/books';
+import { BOOKS, isPropheticBook } from '../data/books';
 import { DETAILS, type BookDetail, type DetailEvent } from '../data/details';
 import type { Item } from '../data/types';
+import { distractorSets } from './distractors';
 import { pickDistractors, seededShuffle } from './rng';
 
 const bookName = new Map(BOOKS.map((b) => [b.id, b.name]));
@@ -75,20 +76,26 @@ function eventItems(d: BookDetail): Item[] {
     const shared = (refCount.get(e.ref) ?? 0) > 1;
 
     // Episode → what happened. The hardest and most useful form.
+    //
+    // Own book first, as before. The fallback used to be the whole canon; it is
+    // now the surrounding division, widening only as needed (#12). That rule is
+    // this question's medium set, so it is kept here rather than handed to
+    // distractorSets — the helper still supplies the easy and hard alternates.
+    const whatSets = distractorSets(
+      d.book,
+      (x) => (detailByBook.get(x.id)?.events ?? []).map((y) => y.what),
+      e.what, `evw-${key}`, 'division',
+    );
     items.push({
       id: `det-ev-what-${key}`, kind: 'mcq', topic: 'events', tier: 2, book: d.book,
       prompt: shared
         ? `${ref(d, e.ref)} — what happens in the episode known as "${e.name}"?`
         : `${ref(d, e.ref)} — what happens?`,
       answer: e.what,
-      distractors: pickDistractors(
-        // Own book first, as before. The fallback used to be the whole canon;
-        // it is now the surrounding division, widening only as needed (#12).
-        ownWhats.length >= 6
-          ? ownWhats
-          : nearbyPool(d.book, (x) => (detailByBook.get(x.id)?.events ?? []).map((y) => y.what), e.what),
-        e.what, 3, `evw-${key}`,
-      ),
+      distractors: ownWhats.length >= 6
+        ? pickDistractors(ownWhats, e.what, 3, `evw-${key}`)
+        : whatSets.distractors,
+      distractorsBy: whatSets.distractorsBy,
       explain: [e.detail, e.where ? `Where: ${e.where}.` : null].filter(Boolean).join(' '),
     });
 
@@ -97,13 +104,10 @@ function eventItems(d: BookDetail): Item[] {
       id: `det-ev-ref-${key}`, kind: 'mcq', topic: 'chapters', tier: 3, book: d.book,
       prompt: `Where does this happen? "${e.what}"`,
       answer: `${abbr} ${e.ref}`,
-      distractors: pickDistractors(
-        nearbyPool(
-          d.book,
-          (x) => (detailByBook.get(x.id)?.events ?? []).map((y) => `${bookAbbr.get(x.id)} ${y.ref}`),
-          `${abbr} ${e.ref}`,
-        ),
-        `${abbr} ${e.ref}`, 3, `evr-${key}`,
+      ...distractorSets(
+        d.book,
+        (x) => (detailByBook.get(x.id)?.events ?? []).map((y) => `${bookAbbr.get(x.id)} ${y.ref}`),
+        `${abbr} ${e.ref}`, `evr-${key}`, 'book',
       ),
       explain: `${e.name} — ${ref(d, e.ref)}.`,
     });
@@ -114,13 +118,16 @@ function eventItems(d: BookDetail): Item[] {
       const banned = booksWithEventName(e.name);
       // Same-division books, widening only as far as it must — "Miriam's
       // leprosy" should offer the books of Moses, not Colossians (#12). The
-      // ban is folded in so the widening counts only offerable books.
-      const pool = nearbyPool(d.book, (x) => (banned.has(x.name) ? [] : [x.name]), name);
+      // ban is folded in so the widening counts only offerable books, in every
+      // difficulty's pool alike.
       items.push({
         id: `det-ev-book-${key}`, kind: 'mcq', topic: 'events', tier: 2, book: d.book,
         prompt: `In which book do we read about this: ${e.name}?`,
         answer: name,
-        distractors: pickDistractors(pool, name, 3, `evb-${key}`),
+        ...distractorSets(
+          d.book, (x) => (banned.has(x.name) ? [] : [x.name]), name,
+          `evb-${key}`, 'division',
+        ),
         explain: `${ref(d, e.ref)} — ${e.what}.`,
       });
     }
@@ -161,16 +168,15 @@ function eventItems(d: BookDetail): Item[] {
 
     // The detail that separates this episode from every similar one.
     if (e.detail) {
-      const details = nearbyPool(
-        d.book,
-        (x) => (detailByBook.get(x.id)?.events ?? []).map((y) => y.detail).filter((y): y is string => !!y),
-        e.detail,
-      );
       items.push({
         id: `det-ev-detail-${key}`, kind: 'mcq', topic: 'events', tier: 3, book: d.book,
         prompt: `Which detail belongs to this episode: ${e.name} (${ref(d, e.ref)})?`,
         answer: e.detail,
-        distractors: pickDistractors(details, e.detail, 3, `evd-${key}`),
+        ...distractorSets(
+          d.book,
+          (x) => (detailByBook.get(x.id)?.events ?? []).map((y) => y.detail).filter((y): y is string => !!y),
+          e.detail, `evd-${key}`, 'division',
+        ),
         explain: e.what,
       });
     }
@@ -344,9 +350,9 @@ function frameItems(d: BookDetail): Item[] {
       id: `det-verse-${d.book}-${i}`, kind: 'mcq', topic: 'chapters', tier: 3, book: d.book,
       prompt: `Where is this from? "${v.text}"`,
       answer: v.ref,
-      distractors: pickDistractors(
-        nearbyPool(d.book, (x) => (detailByBook.get(x.id)?.verses ?? []).map((y) => y.ref), v.ref),
-        v.ref, 3, `vs-${d.book}-${i}`,
+      ...distractorSets(
+        d.book, (x) => (detailByBook.get(x.id)?.verses ?? []).map((y) => y.ref),
+        v.ref, `vs-${d.book}-${i}`, 'book',
       ),
       explain: `${name} — ${d.purpose}`,
     });

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -1,8 +1,9 @@
-import { BOOKS, isPropheticBook, nearbyPool } from '../data/books';
+import { BOOKS, isPropheticBook } from '../data/books';
 import { PEOPLE, PLACES } from '../data/people';
 import { ERAS, EVENTS } from '../data/timeline';
 import { AUTHORED, LIST_DECOYS, LISTS } from '../data/extras';
 import type { Item } from '../data/types';
+import { distractorSets } from './distractors';
 import { buildDetailItems } from './generate-detail';
 import { buildEssentialItems } from './generate-essentials';
 import { pickDistractors, seededShuffle } from './rng';
@@ -70,18 +71,19 @@ function buildBookItems(): Item[] {
         id: `gen-chapter-${b.id}-${kc.ch}`, kind: 'mcq', topic: 'chapters', tier: 2, book: b.id,
         prompt: `What happens in ${b.name} ${kc.ch}?`,
         answer: kc.what,
-        distractors: pickDistractors(
-          nearbyPool(b.id, (x) => x.keyChapters.map((k) => k.what), kc.what),
-          kc.what, 3, `chwhat-${b.id}-${kc.ch}`,
+        // Chapter Content, so `hard` may stay inside this one book (#36).
+        ...distractorSets(
+          b.id, (x) => x.keyChapters.map((k) => k.what), kc.what,
+          `chwhat-${b.id}-${kc.ch}`, 'book',
         ),
       });
       items.push({
         id: `gen-locate-${b.id}-${kc.ch}`, kind: 'mcq', topic: 'chapters', tier: 2, book: b.id,
         prompt: `Where does this happen? "${kc.what}"`,
         answer: `${b.name} ${kc.ch}`,
-        distractors: pickDistractors(
-          nearbyPool(b.id, (x) => x.keyChapters.map((k) => `${x.name} ${k.ch}`), `${b.name} ${kc.ch}`),
-          `${b.name} ${kc.ch}`, 3, `loc-${b.id}-${kc.ch}`,
+        ...distractorSets(
+          b.id, (x) => x.keyChapters.map((k) => `${x.name} ${k.ch}`), `${b.name} ${kc.ch}`,
+          `loc-${b.id}-${kc.ch}`, 'book',
         ),
       });
     }
@@ -96,12 +98,17 @@ function buildBookItems(): Item[] {
       // The ban is folded into the extract rather than applied afterwards, so
       // the widening in nearbyPool counts only books it can actually offer —
       // filtering after the fact could leave a division short and still stop (#12).
-      const pool = nearbyPool(b.id, (x) => (banned.has(x.name) ? [] : [x.name]), b.name);
+      // It stays inside the extract for all three difficulty pools, for the
+      // same reason.
       items.push({
         id: `gen-event-${b.id}-${slug(ev)}`, kind: 'mcq', topic: 'events', tier: 2, book: b.id,
         prompt: `In which book does this occur: ${ev}?`,
         answer: b.name,
-        distractors: pickDistractors(pool, b.name, 3, `ev-${b.id}-${ev}`),
+        // The answer is a book, so the tightest `hard` can be is the division.
+        ...distractorSets(
+          b.id, (x) => (banned.has(x.name) ? [] : [x.name]), b.name,
+          `ev-${b.id}-${ev}`, 'division',
+        ),
         explain: b.oneLine,
       });
     }
@@ -112,10 +119,7 @@ function buildBookItems(): Item[] {
         id: `gen-verse-${b.id}`, kind: 'mcq', topic: 'chapters', tier: 3, book: b.id,
         prompt: `Which book is this from? "${b.keyVerse.text}"`,
         answer: b.name,
-        distractors: pickDistractors(
-          nearbyPool(b.id, (x) => [x.name], b.name),
-          b.name, 3, `kv-${b.id}`,
-        ),
+        ...distractorSets(b.id, (x) => [x.name], b.name, `kv-${b.id}`, 'book'),
         explain: `${b.keyVerse.ref} (ESV)`,
       });
     }

--- a/src/lib/srs.ts
+++ b/src/lib/srs.ts
@@ -3,6 +3,7 @@
  * every card comes back at least once before the exam date. A card scheduled for
  * 60 days out is useless when the test is in 40.
  */
+import type { Difficulty } from '../data/types';
 import { shuffle } from './rng';
 
 export type Grade = 0 | 1 | 2 | 3; // again | hard | ok | easy
@@ -94,6 +95,35 @@ export interface QueueOptions {
   newLimit: number;
   /** Max total cards this session. */
   sessionLimit: number;
+  /**
+   * Which cards a truncated session should favour (#36). Absent means
+   * `medium`, which is no weighting at all.
+   */
+  difficulty?: Difficulty;
+}
+
+/**
+ * How far a point of ease can move a card in the queue, expressed in days of
+ * borrowed urgency. Large enough to reorder cards of similar overdue-ness,
+ * small enough that a badly overdue card still leads — the queue's first duty
+ * is that nothing sails past its due date unreviewed.
+ */
+const EASE_LEAN_DAYS = 3;
+
+/**
+ * Selection priority for a due card: lower goes first, and it is the cut at
+ * the session limit that really consumes this.
+ *
+ * `ease` is the scheduler's own record of how hard *this* user finds *this*
+ * card, which makes it the honest signal for the setting: `hard` pulls forward
+ * the cards you keep fumbling, `easy` pulls forward the ones you have nearly
+ * got. `medium` returns the bare due date — the same number buildQueue has
+ * always sorted on, so that path is unchanged rather than merely equivalent.
+ */
+function priority(c: CardState, difficulty: Difficulty): number {
+  if (difficulty === 'medium') return c.due;
+  const lean = difficulty === 'hard' ? 1 : -1;
+  return c.due + lean * (c.ease - 2.5) * EASE_LEAN_DAYS * DAY;
 }
 
 /**
@@ -116,13 +146,19 @@ export function buildQueue(
     else if (c.due <= now) due.push(id);
   }
 
-  due.sort((a, b) => cards[a].due - cards[b].due);
+  const difficulty = opts.difficulty ?? 'medium';
+  due.sort((a, b) => priority(cards[a], difficulty) - priority(cards[b], difficulty));
   const picked = [...due, ...fresh.slice(0, opts.newLimit)];
   // Order matters twice here, for different reasons.
   //
   // Selecting: sort by how overdue a card is, interleave the books, and only
   // then cut to the session limit — so a truncated session still takes the
   // most urgent cards and a spread of books, not the first N of one.
+  //
+  // The difficulty setting leans on that sort and nothing else (#36): it
+  // changes which cards win the cut, not how they are spread or presented.
+  // New cards are left out of the lean deliberately — every one of them has
+  // the same seeded ease, so there is no signal there to weight on.
   //
   // Presenting: shuffle what survived. The selection above is deterministic,
   // so without this you meet the same cards in the same order every day and

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,10 +1,17 @@
 import type { CardState } from './srs';
+import type { Difficulty } from '../data/types';
 
 export interface Settings {
   /** ISO date of the quiz. Drives the study plan and the SRS interval clamp. */
   examDate: string;
   newLimit: number;
   sessionLimit: number;
+  /**
+   * How tightly wrong options are drawn, and which cards the queue favours.
+   * Defaults to `medium`, which is the behaviour that predates the setting,
+   * so a store written before #36 back-fills to no change at all.
+   */
+  difficulty: Difficulty;
 }
 
 export interface SessionLog {
@@ -26,6 +33,7 @@ export const DEFAULT_SETTINGS: Settings = {
   examDate: '2026-10-31',
   newLimit: 20,
   sessionLimit: 60,
+  difficulty: 'medium',
 };
 
 export function emptyStore(): Store {

--- a/src/lib/useStore.ts
+++ b/src/lib/useStore.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { onAuthStateChanged, type User } from 'firebase/auth';
 import { doc, onSnapshot, setDoc } from 'firebase/firestore';
 import { auth, db, isAllowedEmail } from './firebase';
-import { emptyStore, type Settings, type Store } from './storage';
+import { DEFAULT_SETTINGS, emptyStore, type Settings, type Store } from './storage';
 import type { CardState, Grade } from './srs';
 import {
   applyAnswer,
@@ -43,7 +43,13 @@ export function useStore() {
     return onSnapshot(
       ref,
       (snap) => {
-        const data = snap.exists() ? (snap.data() as Store) : emptyStore();
+        const saved = snap.exists() ? (snap.data() as Store) : emptyStore();
+        // A document written before a setting existed simply has no value for
+        // it, and every reader downstream trusts Settings to be complete. Fill
+        // the gaps from the defaults on the way in, the way importStore and the
+        // E2E hook already do, so #36's difficulty control has something to
+        // show an account that predates it.
+        const data: Store = { ...saved, settings: { ...DEFAULT_SETTINGS, ...saved.settings } };
         storeRef.current = data;
         setStore(data);
         setStoreReady(true);

--- a/src/styles.css
+++ b/src/styles.css
@@ -593,8 +593,37 @@ textarea.input { min-height: 90px; resize: vertical; width: 100%; }
 .seg-opt:hover { color: var(--color-text); }
 .seg-opt[aria-checked='true'], .seg-opt[aria-pressed='true'], .seg-opt.active { background: var(--color-accent-fill); color: var(--color-on-accent); }
 
-/* header theme switch: sized down to sit with the countdown + sign-out chrome */
-.theme-seg .seg-opt { padding: 5px 11px; font-size: 12px; }
+/* A card is a flex column, so a stretch-aligned control would run the full
+   plate width; a segmented switch should stay the width of its own options. */
+.card > .seg { align-self: flex-start; }
+
+/* The notes under a segmented choice in the settings panel (#36). All the
+   options stay legible at once — the current one is the only one lit — because
+   the reader is comparing what the settings *do*, not confirming a label. */
+.choice-notes { display: grid; gap: 2px; margin: 0; }
+.choice-notes > div {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: 14px;
+  padding: 9px 12px;
+  border-left: 2px solid transparent;
+  color: color-mix(in srgb, var(--color-text) 52%, transparent);
+  transition: background var(--dur-tap) var(--ease-out), color var(--dur-tap) var(--ease-out);
+}
+.choice-notes > div.is-current {
+  border-left-color: var(--color-accent);
+  background: var(--tint-surface);
+  color: var(--color-text);
+}
+.choice-notes dt {
+  font-family: var(--font-heading);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  line-height: 1.7;
+}
+.choice-notes dd { margin: 0; font-size: 13px; line-height: 1.55; }
 
 /* ==================================================================== data */
 table.data { width: 100%; border-collapse: collapse; font-size: 14px; }

--- a/src/views/Plan.tsx
+++ b/src/views/Plan.tsx
@@ -16,6 +16,12 @@ export default function Plan({ api }: { api: StoreApi }) {
       <div className="section">
         <div className="spread">
           <h2 style={sx({ margin: 0 })}>Study Plan</h2>
+          {/* This stays out of the Settings panel (#36) rather than being
+              deduplicated into it: the quiz date is the single input this whole
+              view is computed from, the schedule below rebuilds as you change
+              it, and the empty state's advice ("move it forward") is only
+              actionable with the field in reach. Same setting, written from two
+              places — the store is the one copy. */}
           <Field label="Quiz date" htmlFor="exam">
             <input
               id="exam"

--- a/src/views/Progress.tsx
+++ b/src/views/Progress.tsx
@@ -4,10 +4,10 @@ import { allItems } from '../lib/generate';
 import { isLeech, strength } from '../lib/srs';
 import { exportStore, importStore, todayISO } from '../lib/storage';
 import type { StoreApi } from '../lib/useStore';
-import { Card, CountUp, Field, Meter, color, space, sx } from '../ui';
+import { Card, CountUp, Meter, color, space, sx } from '../ui';
 
 export default function Progress({ api }: { api: StoreApi }) {
-  const { store, cards, updateSettings, replaceStore, reset, user } = api;
+  const { store, cards, replaceStore, reset, user } = api;
   const items = allItems();
   const fileRef = useRef<HTMLInputElement>(null);
   const [note, setNote] = useState('');
@@ -154,32 +154,9 @@ export default function Progress({ api }: { api: StoreApi }) {
         </div>
       )}
 
-      <div className="section">
-        <h2>Settings</h2>
-        <Card corners>
-          <div className="grid three">
-            <Field label="Quiz date" htmlFor="exam2">
-              <input id="exam2" className="ctl" type="date" style={{ width: '100%' }}
-                value={store.settings.examDate}
-                onChange={(e) => updateSettings({ examDate: e.target.value })} />
-            </Field>
-            <Field label="New cards per session" htmlFor="nl">
-              <input id="nl" className="ctl" type="number" min={5} max={100} style={{ width: '100%' }}
-                value={store.settings.newLimit}
-                onChange={(e) => updateSettings({ newLimit: Number(e.target.value) })} />
-            </Field>
-            <Field label="Max cards per session" htmlFor="sl">
-              <input id="sl" className="ctl" type="number" min={10} max={300} style={{ width: '100%' }}
-                value={store.settings.sessionLimit}
-                onChange={(e) => updateSettings({ sessionLimit: Number(e.target.value) })} />
-            </Field>
-          </div>
-          <p className="tiny muted" style={sx({ marginTop: space[4] })}>
-            Review intervals are capped so no card is scheduled past your quiz date without one more
-            look at it.
-          </p>
-        </Card>
-      </div>
+      {/* The quiz date and the session limits used to live here as a "Settings"
+          section. They moved to the Settings panel (#36) so there is one place
+          to look for a preference. */}
 
       <div className="section">
         <h2>Your data</h2>

--- a/src/views/Quiz.tsx
+++ b/src/views/Quiz.tsx
@@ -205,6 +205,7 @@ export default function Quiz({ api }: { api: StoreApi }) {
           starred={store.starred.includes(item.id)}
           onToggleStar={() => toggleStar(item.id)}
           counter={`${pos + 1} / ${queue.length}`}
+          difficulty={store.settings.difficulty}
         />
       </div>
       <div className="row" style={{ marginTop: space[4] }}>

--- a/src/views/Review.tsx
+++ b/src/views/Review.tsx
@@ -30,6 +30,7 @@ export default function Review({ api }: { api: StoreApi }) {
     const q = buildQueue(items.map((i) => i.id), cards, {
       newLimit: store.settings.newLimit,
       sessionLimit: store.settings.sessionLimit,
+      difficulty: store.settings.difficulty,
     });
     setQueue(q);
     setPos(0);
@@ -132,6 +133,7 @@ export default function Review({ api }: { api: StoreApi }) {
           starred={store.starred.includes(item.id)}
           onToggleStar={() => toggleStar(item.id)}
           counter={`${pos + 1} / ${queue.length}`}
+          difficulty={store.settings.difficulty}
         />
       </div>
       <div className="row" style={sx({ marginTop: space[4] })}>

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -1,0 +1,135 @@
+/**
+ * The settings panel (#36).
+ *
+ * One place for everything the reader can tune, gathered from where these
+ * controls used to be scattered: the theme switch was header chrome, and the
+ * session limits were a section buried under the Progress charts. A setting the
+ * user has to go hunting for may as well not exist.
+ *
+ * Two stores meet here on purpose and stay separate. Difficulty and the study
+ * limits are account state and go through `updateSettings` to Firestore, so they
+ * follow you to any device. Theme does not: it lives in localStorage (see
+ * lib/theme.ts) because it must apply before React paints and before sign-in, or
+ * the boot splash flashes the wrong theme. The panel is a shared surface for the
+ * two, not a merge of them.
+ */
+import { DIFFICULTIES, type Difficulty } from '../data/types';
+import { useThemeMode, type ThemeMode } from '../lib/theme';
+import type { StoreApi } from '../lib/useStore';
+import { copy } from '../copy';
+import { Card, Field, Segmented, space, sx } from '../ui';
+
+/** Light default, then Dark, then follow-the-OS System. */
+const THEME_OPTIONS: { label: string; value: ThemeMode }[] = [
+  { label: copy.theme.light, value: 'light' },
+  { label: copy.theme.dark, value: 'dark' },
+  { label: copy.theme.system, value: 'system' },
+];
+
+const DIFFICULTY_OPTIONS = DIFFICULTIES.map((value) => ({
+  label: copy.settings.difficulty.options[value].label,
+  value,
+}));
+
+export default function Settings({ api }: { api: StoreApi }) {
+  const { store, updateSettings } = api;
+  const [themeMode, setTheme] = useThemeMode();
+  const { display, difficulty, study } = copy.settings;
+
+  return (
+    <div className="stack-in">
+      <div className="section">
+        <h2>{study.heading}</h2>
+        <p className="small muted">{study.help}</p>
+        <Card corners>
+          <div className="grid three">
+            {/* Ids kept from the Progress section this moved out of, so the
+                quiz date the Study Plan writes and the one here stay one field
+                under two names. */}
+            <Field label={study.examDate} htmlFor="exam2">
+              <input
+                id="exam2"
+                className="ctl"
+                type="date"
+                style={{ width: '100%' }}
+                value={store.settings.examDate}
+                onChange={(e) => updateSettings({ examDate: e.target.value })}
+              />
+            </Field>
+            <Field label={study.newLimit} htmlFor="nl">
+              <input
+                id="nl"
+                className="ctl"
+                type="number"
+                min={5}
+                max={100}
+                style={{ width: '100%' }}
+                value={store.settings.newLimit}
+                onChange={(e) => updateSettings({ newLimit: Number(e.target.value) })}
+              />
+            </Field>
+            <Field label={study.sessionLimit} htmlFor="sl">
+              <input
+                id="sl"
+                className="ctl"
+                type="number"
+                min={10}
+                max={300}
+                style={{ width: '100%' }}
+                value={store.settings.sessionLimit}
+                onChange={(e) => updateSettings({ sessionLimit: Number(e.target.value) })}
+              />
+            </Field>
+          </div>
+          <p className="tiny muted" style={sx({ marginTop: space[4], marginBottom: 0 })}>
+            {study.clampNote}
+          </p>
+        </Card>
+      </div>
+
+      <div className="section">
+        <h2>{difficulty.heading}</h2>
+        <p className="small muted">{difficulty.help}</p>
+        <Card corners>
+          <Segmented
+            ariaLabel={difficulty.label}
+            options={DIFFICULTY_OPTIONS}
+            value={store.settings.difficulty}
+            onChange={(next: Difficulty) => updateSettings({ difficulty: next })}
+          />
+          {/* All three notes stay visible: the choice is between mechanisms, and
+              you cannot compare mechanisms you can only see one at a time. */}
+          <dl className="choice-notes">
+            {DIFFICULTIES.map((d) => (
+              <div key={d} className={d === store.settings.difficulty ? 'is-current' : undefined}>
+                <dt>{difficulty.options[d].label}</dt>
+                <dd>{difficulty.options[d].note}</dd>
+              </div>
+            ))}
+          </dl>
+        </Card>
+      </div>
+
+      <div className="section">
+        <h2>{display.heading}</h2>
+        <p className="small muted">{display.help}</p>
+        <Card corners>
+          <div className="spread">
+            <div>
+              <strong className="small">{display.themeCaption}</strong>
+              <p className="tiny muted" style={sx({ margin: `${space[1]} 0 0`, maxWidth: '46ch' })}>
+                {display.themeNote}
+              </p>
+            </div>
+            <Segmented
+              ariaLabel={copy.theme.label}
+              options={THEME_OPTIONS}
+              value={themeMode}
+              onChange={setTheme}
+            />
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/tests/e2e/difficulty.spec.ts
+++ b/tests/e2e/difficulty.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * The difficulty setting (#36).
+ *
+ * Two halves, tested where each actually lives. The option-scoping rules are a
+ * property of the generated bank, so they run in Node against the real
+ * generators — the same reasoning as content-contract.spec.ts. The control
+ * itself is UI, so that half drives the browser.
+ *
+ * The seam rule is the one worth guarding hardest: medium and hard must never
+ * offer an option from the other Testament, because a New Testament book
+ * against an Old Testament question is not a hard choice, just a different
+ * subject (#10, #12). Easy deliberately breaks that rule — that is what makes
+ * it easy — so it is pinned from the other side.
+ */
+import { expect, test } from '@playwright/test';
+import { BOOKS, BOOKS_BY_ID } from '../../src/data/books';
+import { allItems } from '../../src/lib/generate';
+import { openAs, readStore, expectBooted } from './harness';
+
+const BOOK_BY_NAME = new Map(BOOKS.map((b) => [b.name, b]));
+
+/**
+ * Options that name a book, paired with the Testament they belong to.
+ *
+ * Most options are chapter summaries or references and cannot be attributed to
+ * a book by string alone; the ones that are bare book names can, and they are
+ * the only place a seam crossing is observable from the outside. #24 verified
+ * its own rule the same way.
+ */
+function crossings(options: string[] | undefined, ownTestament: string): number {
+  if (!options) return 0;
+  return options.filter((o) => {
+    const book = BOOK_BY_NAME.get(o);
+    return book !== undefined && book.testament !== ownTestament;
+  }).length;
+}
+
+test.describe('difficulty — option scoping', () => {
+  /**
+   * Only Chapter Content and Events are in scope. The seam rule was written for
+   * those two (#24, #27) because a question about one passage should offer
+   * other plausible passages. Book Order is deliberately exempt: "which book
+   * immediately follows Genesis?" is a question about the shape of the whole
+   * canon, so its options have to be able to come from anywhere in it.
+   */
+  const withBook = allItems().filter(
+    (i) => i.book && BOOKS_BY_ID[i.book] && (i.topic === 'chapters' || i.topic === 'events'),
+  );
+
+  test('medium and hard never offer an option from the other Testament', () => {
+    let mediumCrossings = 0;
+    let hardCrossings = 0;
+    const offenders: string[] = [];
+
+    for (const item of withBook) {
+      const own = BOOKS_BY_ID[item.book!].testament;
+      const m = crossings(item.distractors, own);
+      const h = crossings(item.distractorsBy?.hard, own);
+      mediumCrossings += m;
+      hardCrossings += h;
+      if ((m || h) && offenders.length < 5) offenders.push(`${item.id} | ${item.prompt}`);
+    }
+
+    expect(mediumCrossings, `medium crossings, e.g. ${offenders.join(' ; ')}`).toBe(0);
+    expect(hardCrossings, `hard crossings, e.g. ${offenders.join(' ; ')}`).toBe(0);
+  });
+
+  test('easy does reach across the seam, which is what makes it easy', () => {
+    const crossed = withBook.reduce(
+      (n, item) => n + crossings(item.distractorsBy?.easy, BOOKS_BY_ID[item.book!].testament),
+      0,
+    );
+    // A floor rather than an exact count: the number moves whenever the bank
+    // grows, but "easy behaves differently from medium" must not silently stop
+    // being true — that would leave the setting doing nothing.
+    expect(crossed).toBeGreaterThan(0);
+  });
+
+  test('every alternate set offers as many options as the medium one', () => {
+    const thin = withBook.filter((i) => {
+      const base = i.distractors?.length ?? 0;
+      const by = i.distractorsBy;
+      if (!by) return false;
+      return (by.easy && by.easy.length < base) || (by.hard && by.hard.length < base);
+    });
+    // A short pool means a three-choice question, and three choices are easier
+    // than four — which would invert hard mode rather than sharpen it.
+    expect(thin.map((i) => i.id)).toEqual([]);
+  });
+});
+
+test.describe('difficulty — the control', () => {
+  test('the chosen difficulty is saved and survives a reload', async ({ page }) => {
+    await openAs(page, {}, 'settings');
+
+    await page.getByRole('radio', { name: 'Hard' }).click();
+
+    expect((await readStore(page)).settings.difficulty).toBe('hard');
+
+    await page.reload();
+    await expectBooted(page);
+    await expect(page.getByRole('radio', { name: 'Hard' })).toBeChecked();
+  });
+
+  test('an existing account with no difficulty saved falls back to medium', async ({ page }) => {
+    await openAs(page, {}, 'settings');
+
+    // The setting postdates the store format, so a store written before #36 has
+    // no such key. It must read as medium — the behaviour that predates the
+    // setting — rather than leaving the control with nothing selected.
+    await expect(page.getByRole('radio', { name: 'Medium' })).toBeChecked();
+  });
+
+  test('the theme switch moved to the panel and still drives the page', async ({ page }) => {
+    await openAs(page, {}, 'settings');
+
+    // It used to sit in the header; #36 gave it a home alongside the rest.
+    await expect(page.locator('header').getByRole('radio', { name: 'Dark' })).toHaveCount(0);
+
+    await page.getByRole('radio', { name: 'Dark' }).click();
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+  });
+});

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -9,6 +9,7 @@ const TABS = [
   { label: 'Reference', hash: 'library', heading: 'Reference' },
   { label: 'Study Plan', hash: 'plan', heading: 'Study Plan' },
   { label: 'Progress', hash: 'progress', heading: 'Last 14 days' },
+  { label: 'Settings', hash: 'settings', heading: 'Study' },
 ];
 
 const tab = (page: Page, label: string) => page.getByRole('navigation').getByRole('button', { name: label });

--- a/tests/e2e/progress.spec.ts
+++ b/tests/e2e/progress.spec.ts
@@ -4,7 +4,9 @@ import { ITEM, daysFromNow, daysUntil, dueCard, expectBooted, expectStat, leechC
 
 test.describe('progress and settings', () => {
   test('session limits are editable and survive a reload', async ({ page }) => {
-    await openAs(page, {}, 'progress');
+    // These three fields moved to the Settings panel in #36; the ids are
+    // unchanged, so only the tab they are reached through differs.
+    await openAs(page, {}, 'settings');
 
     await page.locator('#nl').fill('35');
     await page.locator('#sl').fill('120');
@@ -18,7 +20,7 @@ test.describe('progress and settings', () => {
   });
 
   test('the quiz date drives the countdown in the header', async ({ page }) => {
-    await openAs(page, {}, 'progress');
+    await openAs(page, {}, 'settings');
 
     await page.locator('#exam2').fill(daysFromNow(30));
 
@@ -26,12 +28,12 @@ test.describe('progress and settings', () => {
     expect((await readStore(page)).settings.examDate).toBe(daysFromNow(30));
   });
 
-  test('the study plan and Progress share one quiz date', async ({ page }) => {
+  test('the study plan and Settings share one quiz date', async ({ page }) => {
     await openAs(page, {}, 'plan');
 
     await page.locator('#exam').fill(daysFromNow(45));
 
-    await page.getByRole('button', { name: 'Progress' }).click();
+    await page.getByRole('button', { name: 'Settings' }).click();
     await expect(page.locator('#exam2')).toHaveValue(daysFromNow(45));
   });
 


### PR DESCRIPTION
Closes #36.

Settings were scattered — the study fields inside Progress, the theme switch in the header, the quiz date in two places. There is now a **Settings** tab holding Study, Difficulty and Display.

## Difficulty

Decides where a question's wrong answers come from.

| | Wrong answers drawn from | Queue |
|---|---|---|
| **Easy** | anywhere in the canon, Testaments may mix | favours cards you answer well |
| **Medium** *(default)* | books near the answer's own, never crossing the seam | unchanged |
| **Hard** | Chapter Content: the answer's **own book**. Events: its own division | favours what you keep missing |

Medium is exactly what the trainer has always done, so an existing user sees no change at all — including a store written before this, which back-fills to `medium`.

## Two decisions worth reviewing

**Options are baked in, not regenerated.** All three sets are computed at generation and stored on the item (`distractorsBy`). Item ids are what SRS history is keyed on — a bank that regenerated per difficulty would detach every card a user had ever reviewed the moment they touched the control. This also keeps `allItems()` a cached singleton instead of forcing a difficulty parameter through five call sites and the `ITEMS_BY_ID` map.

**A strict pool that comes up short widens rather than offering three options.** A three-choice question is *easier* than a four-choice one, so falling short would invert hard mode rather than sharpen it.

One consequence worth naming: for **Events**, hard and medium draw from the same pool and differ only by seed, because medium already starts at the division. The real separation lives in Chapter Content. That is what the issue specifies, but it means hard is a smaller step for Events than for chapters.

## Queue lean

Uses the per-card `ease` the scheduler already tracks — the measure of what *this* user finds hard. It shifts a card's effective due date by at most ±3.6 days: enough to reorder cards of similar urgency, never enough to let a badly overdue card slip. Selection still runs before the session cut, `interleave` and the final `shuffle()` are untouched, and `medium` returns the identical comparator so today's behaviour is preserved exactly.

## Test plan

- New `tests/e2e/difficulty.spec.ts`: across the whole bank, **zero** medium or hard options cross the Testament seam for Chapter Content and Events; easy ones deliberately do; no alternate set is thinner than the medium one. Plus browser coverage for persistence, the pre-#36 fallback, and the relocated theme switch.
- `scripts/validate.ts` extended — the three mcq gates (short pool, answer-as-option, duplicates) now run over the easy and hard sets too. They previously inspected only the default set, so a leaked answer would have shipped invisibly to anyone who had moved off it. All 6,098 items pass.
- Medium verified byte-identical: dumping `id + distractors` for all 6,098 items against a pristine copy of the generators diffs empty.
- `npm run check` clean; `npm run validate` clean; `npm run test:e2e --workers=2` (CI concurrency) 124/124.
- `tests/e2e/progress.spec.ts` retargeted to the Settings tab (element ids unchanged) and `navigation.spec.ts` gained a Settings row.
- Eyeballed in both themes.