### PR TITLE
Make difficulty a real setting, and make the study plan drive what you study

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist
 
 # Firebase deploy cache
 /.firebase/
+
+# Local Claude Code launch config
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **Difficulty became a real setting, and the study plan started driving what
-  you study** ([#38]).
+  you study** ([#40]).
 
   **The setting was doing almost nothing.** It swapped a question's wrong
   options and leaned the review queue by ease — and only on the third of the
@@ -50,7 +50,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   for fine detail first, and does not hand a missed card back inside the same
   session — you meet it again tomorrow, cold.
 
-- **The study plan now decides what your daily review asks you** ([#38]). The
+- **The study plan now decides what your daily review asks you** ([#40]). The
   five phases have always been rendered on the Plan tab, and the Dashboard has
   always named the current one, but nothing filtered the queue by them, so
   following the plan was left entirely to your own discipline. The daily review
@@ -149,7 +149,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **Missing the last card of a review session graded it three times** ([#38]).
+- **Missing the last card of a review session graded it three times** ([#40]).
   A missed card is requeued to the end of the session; when it *was* the end,
   the next card had the same id, the card component was never remounted, and
   its reset never ran. The card came back already answered — no retrieval,
@@ -159,12 +159,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   leech, and skewed the accuracy on your Progress tab. The session card is now
   keyed on its position in the queue rather than on the item.
 
-- **Six questions offered the book they were asking about** ([#38]). "Which
+- **Six questions offered the book they were asking about** ([#40]). "Which
   book immediately precedes Leviticus?" listed Leviticus among the choices.
   Distractor selection excluded the *answer* but had never been told about the
   book named in the prompt.
 
-- **Clearing a field in Settings wrote a broken value** ([#38]). The number
+- **Clearing a field in Settings wrote a broken value** ([#40]). The number
   inputs committed `0` for an emptied field, so a moment's editing of Max cards
   per session could commit `0` and send "Start review session" straight to a
   finished session. Worse, clearing the quiz date committed an empty string:
@@ -175,7 +175,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   The fields are now clamped on commit rather than on screen, so they are still
   comfortable to edit.
 
-- **A wrong option could be a second correct answer** ([#38]). Event questions
+- **A wrong option could be a second correct answer** ([#40]). Event questions
   excluded the people who took part from their wrong options, but only from the
   medium pool. Tightening the hard pool to the same book would have started
   offering genuine participants as wrong answers — a defect no content check
@@ -201,7 +201,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- **Accessibility** ([#38]). The app had no `<h1>` and never moved focus when
+- **Accessibility** ([#40]). The app had no `<h1>` and never moved focus when
   you changed tabs, so a screen-reader user activating Quiz heard nothing and
   was left in the navigation. Ordering questions signalled a correctly placed
   row by border colour alone, the ordering buttons dropped focus at the ends of
@@ -209,7 +209,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   are fixed.
 
 - **Exporting your progress** no longer risks a silent no-op in Firefox and
-  Safari ([#38]): the download link is placed in the document before it is
+  Safari ([#40]): the download link is placed in the document before it is
   clicked, and its blob is released a tick later rather than immediately.
 
 - **The sign-in screen shows the mark, the verse, and Google's own glyph**
@@ -348,4 +348,4 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [#34]: https://github.com/godwinlaw/scripture-mastery/issues/34
 
 [#36]: https://github.com/godwinlaw/scripture-mastery/issues/36
-[#38]: https://github.com/godwinlaw/scripture-mastery/issues/38
+[#40]: https://github.com/godwinlaw/scripture-mastery/pull/40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Difficulty became a real setting, and the study plan started driving what
+  you study** ([#38]).
+
+  **The setting was doing almost nothing.** It swapped a question's wrong
+  options and leaned the review queue by ease — and only on the third of the
+  bank that carried alternate option sets at all. Every People, Places, Family,
+  Book Order, Numbers, Timeline and Book Summaries question had none, so it
+  fell back to its medium set, and plenty of those pools were canon-wide. The
+  result: *hard* went on offering New Testament options against Old Testament
+  questions. Measured across the bank, **637 of them**. Every question now
+  carries all three sets — 5,915 of 5,926, the remainder being hand-written
+  items that draw their options from outside the canon — and hard's
+  cross-Testament count is **zero**.
+
+  Each family is scoped as tightly as its own question allows, widening only
+  when the tight pool cannot fill the card. People are drawn from the same
+  book, then the same era; family facts from the same household; eras from
+  adjacent ones. **Book Order is deliberately exempt from the seam rule**:
+  "which book immediately follows Malachi?" has a New Testament answer, so
+  fencing it by Testament would identify the answer without knowing the canon
+  at all. It is scoped by *canonical distance* instead — neighbours within four
+  positions on hard, and books a dozen positions away on easy.
+
+  **Difficulty now changes four things, not one.** How many options you are
+  offered — three, four, or six, which is the dial you feel on every single
+  card. Where the wrong ones come from. Whether a reference has to be named
+  from memory before the choices appear, and whether the explanation is offered
+  as a hint first. And how new material is introduced.
+
+  **New material is no longer introduced in canonical order at every setting.**
+  It always had been: unseen cards arrive in the bank's generation order, the
+  queue took the first *n*, and the within-session shuffle ([#11]) never
+  touched that because it only reorders cards already chosen. So Build the
+  Frame marched Genesis-first no matter what you set — fine on *easy*, where
+  building the frame front to back is the whole pedagogy, and far too
+  predictable on *hard*. Easy still walks the canon from Genesis. Hard now
+  draws from anywhere in the current scope, spanning **27 books where easy
+  spans 3**, with only **2 of 10** cards repeating the following day. The draw
+  is seeded per day rather than random, so a reload does not deal a new hand
+  mid-session. Hard also introduces half again as much new material, reaches
+  for fine detail first, and does not hand a missed card back inside the same
+  session — you meet it again tomorrow, cold.
+
+- **The study plan now decides what your daily review asks you** ([#38]). The
+  five phases have always been rendered on the Plan tab, and the Dashboard has
+  always named the current one, but nothing filtered the queue by them, so
+  following the plan was left entirely to your own discipline. The daily review
+  is now drawn from whichever phase you are in, the Quiz offers **This week's
+  plan** as a scope, and the review screen names the phase before you start
+  rather than letting you discover a short session and read it as a bug. When a
+  phase runs dry the queue quietly widens to the rest of the bank instead of
+  claiming there is nothing to study, and **Study everything instead** sets the
+  plan aside for one session without changing the setting. It can be turned off
+  entirely, and defaults to on.
+
+  Making the plan real exposed why it had been safe to leave decorative:
+  `buildSchedule` anchored its start date to *today* on every call, so today was
+  always inside week 1 and the current phase was always Phase 1. Harmless while
+  nothing consumed it — it is why the Dashboard always read "Week 1" — but as a
+  filter it would have pinned every member to Book Order and Book Summaries,
+  330 of 6,098 questions, until the exam date passed. The schedule is now
+  anchored to a persisted plan start, derived from your earliest recorded
+  session so a returning member is not sent back to the beginning, and a member
+  who has run out of runway lands in Phase 5's mixed review rather than nowhere.
+
+
 - **A Settings panel, and a difficulty you can choose** ([#36]). Settings had
   been scattered — the study fields inside Progress, the theme switch in the
   header, the quiz date in two places — so there was no one screen to go to.
@@ -83,6 +149,38 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Missing the last card of a review session graded it three times** ([#38]).
+  A missed card is requeued to the end of the session; when it *was* the end,
+  the next card had the same id, the card component was never remounted, and
+  its reset never ran. The card came back already answered — no retrieval,
+  which is the entire point of requeueing it — and the only way forward was
+  Continue, which graded the same miss again. One genuine miss recorded three
+  reviews and **three lapses**, one short of the threshold that marks a card a
+  leech, and skewed the accuracy on your Progress tab. The session card is now
+  keyed on its position in the queue rather than on the item.
+
+- **Six questions offered the book they were asking about** ([#38]). "Which
+  book immediately precedes Leviticus?" listed Leviticus among the choices.
+  Distractor selection excluded the *answer* but had never been told about the
+  book named in the prompt.
+
+- **Clearing a field in Settings wrote a broken value** ([#38]). The number
+  inputs committed `0` for an emptied field, so a moment's editing of Max cards
+  per session could commit `0` and send "Start review session" straight to a
+  finished session. Worse, clearing the quiz date committed an empty string:
+  the header rendered "NaN days until Invalid Date", and inside the scheduler
+  the exam clamp — the app's one deliberate deviation from SM-2, which
+  guarantees every card is seen at least once more before the test — silently
+  stopped applying, letting cards schedule past the exam and never come back.
+  The fields are now clamped on commit rather than on screen, so they are still
+  comfortable to edit.
+
+- **A wrong option could be a second correct answer** ([#38]). Event questions
+  excluded the people who took part from their wrong options, but only from the
+  medium pool. Tightening the hard pool to the same book would have started
+  offering genuine participants as wrong answers — a defect no content check
+  can catch, since the checks compare options against *the* answer.
+
 - **The app icon never actually rendered** (found while doing [#23]). Both
   `icon.svg` and `favicon.svg` shipped malformed in [#7]: an XML comment cannot
   contain a literal double hyphen, and the comment documenting the colour
@@ -102,6 +200,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   confusing count mismatch three assertions later.
 
 ### Changed
+
+- **Accessibility** ([#38]). The app had no `<h1>` and never moved focus when
+  you changed tabs, so a screen-reader user activating Quiz heard nothing and
+  was left in the navigation. Ordering questions signalled a correctly placed
+  row by border colour alone, the ordering buttons dropped focus at the ends of
+  the list, and the Correct / Not quite verdict was never announced. All four
+  are fixed.
+
+- **Exporting your progress** no longer risks a silent no-op in Firefox and
+  Safari ([#38]): the download link is placed in the document before it is
+  clicked, and its blob is released a tick later rather than immediately.
 
 - **The sign-in screen shows the mark, the verse, and Google's own glyph**
   ([#23]). The app icon appears at 88px as the app's face rather than a
@@ -239,3 +348,4 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [#34]: https://github.com/godwinlaw/scripture-mastery/issues/34
 
 [#36]: https://github.com/godwinlaw/scripture-mastery/issues/36
+[#38]: https://github.com/godwinlaw/scripture-mastery/issues/38

--- a/README.md
+++ b/README.md
@@ -99,19 +99,25 @@ Change the date in **Progress → Settings** and the schedule re-plans itself.
 | **Daily Review** | The spaced-repetition queue. This is the main event — clear it daily |
 | **Quiz** | Mixed testing under quiz conditions. Filter by scope, topic, single book, or weak spots |
 | **Reference** | Every book opened to five panes — overview, outline, events, people, terms — plus the timeline, 233 people, 54 places, the must-know lists, and the standing lists |
-| **Study Plan** | Week-by-week schedule from today to your quiz date |
+| **Study Plan** | Week-by-week schedule from the day you started to your quiz date |
 | **Progress** | Mastery by book, stuck items, settings, export/import |
 
-**Keyboard:** `1`–`4` pick an option · `Enter` submits or advances · `1`/`2`/`3`
-grade Hard/Good/Easy after a correct answer.
+**Keyboard:** `1`–`6` pick an option (hard offers six) · `Enter` submits or
+advances · `1`/`2`/`3` grade Hard/Ok/Easy after a correct answer.
 
 ---
 
 ## The study plan
 
-Five phases, weighted and laid onto the actual calendar between today and your
-quiz date. The order is the point — the frame comes first because every later
-fact needs somewhere to attach.
+Five phases, weighted and laid onto the actual calendar between the day you
+started and your quiz date. The order is the point — the frame comes first
+because every later fact needs somewhere to attach.
+
+The plan is not just a reading: with **Follow the study plan** on (the default),
+your daily review is drawn from whichever phase you are currently in, and the
+Quiz offers *This week's plan* as a scope. When a phase runs dry the queue
+widens to the rest of the bank rather than telling you there is nothing to
+study, and **Study everything instead** sets it aside for a single session.
 
 1. **Build the Frame** — all 66 books: order, division, author, one-line summary, outline
 2. **Old Testament Sweep** — outline, key chapters, people and their families, events,
@@ -120,6 +126,29 @@ fact needs somewhere to attach.
 4. **Timeline & Connections** — the 14 eras, the must-know and standing lists, the
    two fall dates, and how each book points to Christ
 5. **Mixed Review & Mock Quizzes** — no new material, weak spots only
+
+---
+
+## Difficulty
+
+The setting in **Settings → Difficulty** changes four things at once. It never
+changes which questions exist — item ids are what review history is keyed on,
+so the bank is generated once and the setting only decides what reaches the
+card and which cards reach you.
+
+| | Easy | Medium | Hard |
+|---|---|---|---|
+| Options offered | 3 | 4 | 6 |
+| Wrong options drawn from | anywhere in the canon | books near the answer's own, never across the Testament seam | as close as the question allows — the same book, canonical neighbours, the same era or family |
+| A reference answer | shown as choices | named from memory first | named from memory first, no hint |
+| Hint before answering | yes | no | no |
+| New material | walks the canon in order | interleaved by book | anywhere in scope, unpredictable, half again as much |
+| A card you miss | comes back this session | comes back this session | comes back tomorrow |
+
+Book Order questions are deliberately exempt from the Testament rule — "which
+book immediately follows Malachi?" has a New Testament answer, so fencing it by
+Testament would give the answer away. They are scoped by canonical distance
+instead.
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Dashboard from './views/Dashboard';
 import Review from './views/Review';
 import Quiz from './views/Quiz';
@@ -51,6 +51,36 @@ export default function App() {
     const t = window.setTimeout(() => setSplashHeld(false), SPLASH_MIN_MS);
     return () => window.clearTimeout(t);
   }, []);
+
+  /**
+   * Give the switched-to view the caret (#38).
+   *
+   * `<main key={tab}>` throws the old view away and builds a new one, which is
+   * exactly right for the animation and exactly wrong for anyone who is not
+   * looking at the screen: focus stayed on the nav button it was pressed from,
+   * nothing was announced, and the only way to discover the page had changed
+   * was to tab blindly forward through it. Moving focus into `<main>` — which
+   * carries the view's name, see its `aria-label` below — announces the new
+   * view and starts the next Tab at the top of it.
+   *
+   * Deliberately not on first paint: the app has only just loaded, focus
+   * belongs wherever the browser put it, and yanking it would also fire on
+   * every deep link into a tab. The ref burns the mount and fires on genuine
+   * changes only.
+   *
+   * `:focus { outline: none }` is already the house rule, so a mouse user sees
+   * nothing; a keyboard user still gets the `:focus-visible` ring, which is the
+   * half worth keeping.
+   */
+  const mainRef = useRef<HTMLElement>(null);
+  const settled = useRef(false);
+  useEffect(() => {
+    if (!settled.current) {
+      settled.current = true;
+      return;
+    }
+    mainRef.current?.focus();
+  }, [tab]);
 
   function go(next: string) {
     window.location.hash = next;
@@ -143,6 +173,8 @@ export default function App() {
     );
   }
 
+  const viewLabel = TABS.find((t) => t.id === tab)?.label ?? '';
+
   const examDateLabel = new Date(`${api.store.settings.examDate}T12:00`).toLocaleDateString(
     undefined,
     { month: 'long', day: 'numeric' },
@@ -190,7 +222,28 @@ export default function App() {
         ))}
       </nav>
 
-      <main key={tab} className="screen">
+      {/*
+        Two separate holes, closed together (#38).
+
+        `aria-label` gives `<main>` a name, so the focus move above lands
+        somewhere that announces *which* view arrived rather than an anonymous
+        region. It names the tab, matching the nav item that was just pressed.
+
+        The `<h1>` is the document's one and only, and it names the app rather
+        than the view. Every view opens at `<h2>`, which left the outline with
+        no top at all — a screen reader's heading list started midway down.
+        Naming the *app* here is both the conventional shape (h1 the place, h2
+        the section) and the only one that is safe from the shell: an h1 that
+        repeated the view's name would sit alongside the view's own `<h2>`
+        saying the same words, and the views are a shared surface this change
+        has no business restructuring.
+
+        Visually hidden, not decorative — the header already prints the app
+        name and the nav already marks the current tab, so a third visible copy
+        would be noise to everyone who can see the other two.
+      */}
+      <main key={tab} className="screen" ref={mainRef} tabIndex={-1} aria-label={viewLabel}>
+        <h1 className="sr-only">{copy.appName}</h1>
         {tab === 'home' && <Dashboard api={api} go={go} />}
         {tab === 'review' && <Review api={api} />}
         {tab === 'quiz' && <Quiz api={api} />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,7 +53,7 @@ export default function App() {
   }, []);
 
   /**
-   * Give the switched-to view the caret (#38).
+   * Give the switched-to view the caret (#40).
    *
    * `<main key={tab}>` throws the old view away and builds a new one, which is
    * exactly right for the animation and exactly wrong for anyone who is not
@@ -223,7 +223,7 @@ export default function App() {
       </nav>
 
       {/*
-        Two separate holes, closed together (#38).
+        Two separate holes, closed together (#40).
 
         `aria-label` gives `<main>` a name, so the focus move above lands
         somewhere that announces *which* view arrived rather than an anonymous

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -13,7 +13,7 @@ interface Props {
   /** Shown top-right, e.g. "12 / 40". */
   counter?: string;
   /**
-   * How hard this card should be to answer (#36, #38). Omitted means medium.
+   * How hard this card should be to answer (#36, #40). Omitted means medium.
    *
    * The card reads three dials off `specFor`: how many wrong options to
    * render, whether a reference question opens on the typed bonus round, and
@@ -49,7 +49,7 @@ function matches(input: string, item: Item): boolean {
 }
 
 /**
- * Does this item's explanation simply state its answer? (#38)
+ * Does this item's explanation simply state its answer? (#40)
  *
  * `explain` was written to be read *after* answering, where naming the answer
  * is the whole job — `gen-who-*` builds it as `"${p.name}: ${p.role}."` against
@@ -86,7 +86,7 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
   const inputRef = useRef<HTMLInputElement>(null);
 
   /**
-   * What the ordering list last did, spoken (#38).
+   * What the ordering list last did, spoken (#40).
    *
    * Rearranging was a silent operation: the rows moved, the numbers changed,
    * and a screen reader was told none of it. This is written only by `move`,
@@ -108,7 +108,7 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
    * is strictly harder than recognising one, so getting it this way is worth a
    * grade you would otherwise have to award yourself.
    *
-   * Which is exactly why `easy` skips it (#38): free recall is the hardest
+   * Which is exactly why `easy` skips it (#40): free recall is the hardest
    * thing this app asks for, and asking it of someone who chose the gentlest
    * setting is the wrong first impression. There the choices are on screen
    * immediately. Medium and hard keep the behaviour unchanged.
@@ -123,7 +123,7 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
   /**
    * `explain` is what the card shows *after* answering — the reason the answer
    * is the answer. On easy it is also offered before, folded away behind a
-   * button (#38): a nudge you can choose to take is a different thing from a
+   * button (#40): a nudge you can choose to take is a different thing from a
    * question with the answer written under it, and taking it costs nothing but
    * the satisfaction of not having needed it.
    *
@@ -133,14 +133,14 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
    *
    * Also absent — control and all, not disabled or emptied — wherever the
    * explanation would hand over the answer, which is most of a third of the
-   * bank (#38). See `explainGivesItAway`. A button that cannot be pressed
+   * bank (#40). See `explainGivesItAway`. A button that cannot be pressed
    * without spoiling the card is worse than no button, and an empty gap where
    * one used to be just asks what went missing.
    */
   const offersHint = spec.hintBeforeAnswer && Boolean(item.explain) && !explainGivesItAway(item);
 
   /**
-   * Which wrong options this card offers — and, now, how many of them (#36, #38).
+   * Which wrong options this card offers — and, now, how many of them (#36, #40).
    *
    * The setting used to do nothing here but swap the set: four choices either
    * way, differing only in how obviously wrong three of them were, which is
@@ -193,7 +193,7 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
     setHintOpen(false);
     // The new card's list has never been touched, so nothing is owed to the
     // live region — and a stale sentence from the last one could otherwise be
-    // read out, or re-read, against a list it does not describe (#38).
+    // read out, or re-read, against a list it does not describe (#40).
     setOrderNote('');
     pendingFocus.current = null;
     if (item.kind === 'type' || hasBonusRound) setTimeout(() => inputRef.current?.focus(), 30);
@@ -253,13 +253,13 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
     // Follow the entry, not the slot: the rows are keyed by their text, so
     // React moves the actual DOM node — and a focused node that gets moved
     // loses focus to <body>, whether or not the button it holds ends up
-    // disabled. Restored below, once the new order has rendered (#38).
+    // disabled. Restored below, once the new order has rendered (#40).
     pendingFocus.current = { entry, dir };
     setOrderNote(`${entry}, position ${j + 1} of ${next.length}.`);
   }
 
   /**
-   * Put focus back where the member left it (#38).
+   * Put focus back where the member left it (#40).
    *
    * Walking an entry to the top used to end with focus on nothing: the last
    * press disabled the very button that was pressed, and a keyboard user had
@@ -438,7 +438,7 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
                 <li key={entry} className={`order-item${cls}`}>
                   <span className="num">{i + 1}</span>
                   <span>{entry}</span>
-                  {/* The verdict for this row in a second channel (#38). The
+                  {/* The verdict for this row in a second channel (#40). The
                       tint and the border said it in colour alone — and in the
                       one pair of colours, red against green, most likely to
                       arrive as two identical greys. `role="img"` with a label
@@ -486,7 +486,7 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
               inserted with its text already in it is announced by roughly half
               the screen readers that exist. `move` writes the sentence; every
               other render leaves it exactly as it was, which is what keeps
-              this from narrating the whole card (#38). */}
+              this from narrating the whole card (#40). */}
           <p className="sr-only" aria-live="polite">{orderNote}</p>
           {!revealed && (
             <div className="row" style={{ marginTop: 12 }}>
@@ -499,7 +499,7 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
       {revealed && (
         <div className={`feedback ${wasCorrect ? 'correct' : 'wrong'}`}>
           {/*
-            The verdict, announced (#38).
+            The verdict, announced (#40).
 
             "Correct" and "Not quite" arrived silently: the block is inserted
             after the answer is in, and an insertion is not a change any screen

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { TOPIC_LABELS, type Difficulty, type Item } from '../data/types';
 import type { Grade } from '../lib/srs';
 import { shuffle } from '../lib/rng';
 import { isReference, referenceMatches } from '../lib/reference';
+import { specFor } from '../lib/difficulty';
 
 interface Props {
   item: Item;
@@ -11,7 +12,13 @@ interface Props {
   onToggleStar?: () => void;
   /** Shown top-right, e.g. "12 / 40". */
   counter?: string;
-  /** Which of the item's option sets to offer (#36). Omitted means medium. */
+  /**
+   * How hard this card should be to answer (#36, #38). Omitted means medium.
+   *
+   * The card reads three dials off `specFor`: how many wrong options to
+   * render, whether a reference question opens on the typed bonus round, and
+   * whether the explanation is offered as a hint before answering.
+   */
   difficulty?: Difficulty;
 }
 
@@ -41,39 +48,136 @@ function matches(input: string, item: Item): boolean {
   return targets.some((t) => t === got || (t.length > 4 && got.length > 4 && (t.includes(got) || got.includes(t))));
 }
 
+/**
+ * Does this item's explanation simply state its answer? (#38)
+ *
+ * `explain` was written to be read *after* answering, where naming the answer
+ * is the whole job — `gen-who-*` builds it as `"${p.name}: ${p.role}."` against
+ * an answer of `p.name`, and something like 1,400 items across the bank follow
+ * the same shape. Offering that as a hint beforehand is not a nudge, it is the
+ * answer key with a button in front of it.
+ *
+ * Not `matches`: that one is tuned for grading what a member typed, and its
+ * containment arm only fires past four characters, so it would wave through
+ * "Eve: the first woman" on an item whose answer is "Eve". This is the blunter
+ * comparison on purpose — plain containment of the normalized answer — because
+ * the two failure modes are not symmetric. Suppressing a hint that would have
+ * been safe costs one nudge; showing one that is not costs the question.
+ */
+function explainGivesItAway(item: Item): boolean {
+  const explained = normalize(item.explain ?? '');
+  if (!explained) return false;
+  return [item.answer, ...(item.accepts ?? [])]
+    .map(normalize)
+    .some((a) => a.length > 0 && explained.includes(a));
+}
+
+/** Identifies one move button — direction plus the entry it belongs to. */
+const moveKey = (dir: -1 | 1, entry: string) => `${dir}:${entry}`;
+
 export default function QuestionCard({ item, onGrade, starred, onToggleStar, counter, difficulty }: Props) {
   const [picked, setPicked] = useState<string | null>(null);
   const [typed, setTyped] = useState('');
   const [revealed, setRevealed] = useState(false);
   const [wasCorrect, setWasCorrect] = useState(false);
   const [arranged, setArranged] = useState<string[]>([]);
+  /** Whether the pre-answer hint has been opened. Off until it is asked for. */
+  const [hintOpen, setHintOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  /**
+   * What the ordering list last did, spoken (#38).
+   *
+   * Rearranging was a silent operation: the rows moved, the numbers changed,
+   * and a screen reader was told none of it. This is written only by `move`,
+   * never during a render, so it says one sentence per press and stays quiet
+   * the rest of the time — a live region that updates on every render is a
+   * region nobody can bear to leave switched on.
+   */
+  const [orderNote, setOrderNote] = useState('');
+  /** Every move button on screen, so `move` can hand focus to a specific one. */
+  const moveButtons = useRef(new Map<string, HTMLButtonElement | null>());
+  /** Which button should hold focus once the reordered list has rendered. */
+  const pendingFocus = useRef<{ entry: string; dir: -1 | 1 } | null>(null);
+
+  const spec = specFor(difficulty);
 
   /**
    * Questions whose answer is a place in scripture open with a chance to name
    * it from memory, before any options are on screen (#14). Naming a reference
    * is strictly harder than recognising one, so getting it this way is worth a
    * grade you would otherwise have to award yourself.
+   *
+   * Which is exactly why `easy` skips it (#38): free recall is the hardest
+   * thing this app asks for, and asking it of someone who chose the gentlest
+   * setting is the wrong first impression. There the choices are on screen
+   * immediately. Medium and hard keep the behaviour unchanged.
    */
-  const hasBonusRound = item.kind === 'mcq' && isReference(item.answer);
+  const hasBonusRound = spec.bonusRound && item.kind === 'mcq' && isReference(item.answer);
+
   const [bonusOpen, setBonusOpen] = useState(hasBonusRound);
   const [bonusMissed, setBonusMissed] = useState(false);
   /** Named the reference unprompted — the card grades itself Easy on advance. */
   const [bonusEarned, setBonusEarned] = useState(false);
 
   /**
-   * The setting chooses which of the item's option sets is offered (#36).
+   * `explain` is what the card shows *after* answering — the reason the answer
+   * is the answer. On easy it is also offered before, folded away behind a
+   * button (#38): a nudge you can choose to take is a different thing from a
+   * question with the answer written under it, and taking it costs nothing but
+   * the satisfaction of not having needed it.
+   *
+   * Deliberately absent at medium and hard, where working it out unaided is
+   * the point, and absent once `revealed` — the feedback block already shows
+   * the same text, and two copies of it would just be noise.
+   *
+   * Also absent — control and all, not disabled or emptied — wherever the
+   * explanation would hand over the answer, which is most of a third of the
+   * bank (#38). See `explainGivesItAway`. A button that cannot be pressed
+   * without spoiling the card is worse than no button, and an empty gap where
+   * one used to be just asks what went missing.
+   */
+  const offersHint = spec.hintBeforeAnswer && Boolean(item.explain) && !explainGivesItAway(item);
+
+  /**
+   * Which wrong options this card offers — and, now, how many of them (#36, #38).
+   *
+   * The setting used to do nothing here but swap the set: four choices either
+   * way, differing only in how obviously wrong three of them were, which is
+   * most of why `hard` did not feel hard. Length is the other half of the
+   * dial, and the cheaper half — three choices is a coin flip after one
+   * elimination, six is not — so the card renders 3 / 4 / 6 total.
+   *
+   * It reads that length off the spec and slices; it never generates. The
+   * generators bake `MAX_WRONG_OPTIONS` into the hard set precisely so the
+   * render site can slice down without the bank ever varying by setting, which
+   * would detach every card's SRS history the moment someone touched the
+   * control.
    *
    * `medium` has no entry of its own — it *is* `distractors` — and plenty of
    * items carry no alternates at all, because the essentials lists and the
    * hand-written extras draw their options from somewhere other than the
-   * canon. Both cases land on the same fallback.
+   * canon. Both cases land on the same fallback, and that fallback is only
+   * three long, so `hard` on such an item shows four choices rather than six.
+   * That is the honest outcome: slicing short is fine, inventing options this
+   * question was never given is not.
+   *
+   * The one pool we will swap out from under the setting is one *shorter* than
+   * the medium set, because fewer choices is easier and a thin `hard` set
+   * would invert the setting rather than sharpen it. `scopedSets` already tops
+   * those up at generation; this is the same floor held at the render site, so
+   * a future generator cannot quietly hand `hard` the easiest card on screen.
    */
-  const wrong = item.distractorsBy?.[difficulty ?? 'medium'] ?? item.distractors ?? [];
+  const base = item.distractors ?? [];
+  const pool = item.distractorsBy?.[difficulty ?? 'medium'] ?? base;
+  const wrong = (pool.length < base.length && spec.wrongOptions > pool.length ? base : pool)
+    .slice(0, spec.wrongOptions);
 
   const options = useMemo(
     () => (item.kind === 'mcq' ? shuffle([item.answer, ...wrong]) : []),
-    // Reshuffle per item so the answer is not always in the same slot.
+    // Reshuffle per item so the answer is not always in the same slot. The
+    // count is a pure function of the setting, so `difficulty` already covers
+    // a slice length changing — there is nothing further to key on.
     [item.id, difficulty],
   );
 
@@ -86,6 +190,12 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
     setBonusOpen(hasBonusRound);
     setBonusMissed(false);
     setBonusEarned(false);
+    setHintOpen(false);
+    // The new card's list has never been touched, so nothing is owed to the
+    // live region — and a stale sentence from the last one could otherwise be
+    // read out, or re-read, against a list it does not describe (#38).
+    setOrderNote('');
+    pendingFocus.current = null;
     if (item.kind === 'type' || hasBonusRound) setTimeout(() => inputRef.current?.focus(), 30);
   }, [item.id]);
 
@@ -136,19 +246,52 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
   function move(i: number, dir: -1 | 1) {
     const j = i + dir;
     if (j < 0 || j >= arranged.length) return;
+    const entry = arranged[i];
     const next = arranged.slice();
     [next[i], next[j]] = [next[j], next[i]];
     setArranged(next);
+    // Follow the entry, not the slot: the rows are keyed by their text, so
+    // React moves the actual DOM node — and a focused node that gets moved
+    // loses focus to <body>, whether or not the button it holds ends up
+    // disabled. Restored below, once the new order has rendered (#38).
+    pendingFocus.current = { entry, dir };
+    setOrderNote(`${entry}, position ${j + 1} of ${next.length}.`);
   }
 
-  // Keyboard: 1-4 pick an option, then 1-3 grade. Enter advances.
+  /**
+   * Put focus back where the member left it (#38).
+   *
+   * Walking an entry to the top used to end with focus on nothing: the last
+   * press disabled the very button that was pressed, and a keyboard user had
+   * to tab in from the top of the document to carry on. Layout effect rather
+   * than a plain one so focus lands in the same frame as the reorder, with no
+   * flicker of an unfocused page in between.
+   *
+   * Preference is the button just pressed, so repeated presses keep working
+   * without moving the hands; at the end of its travel that button is disabled
+   * — which the list's ends must stay, it is how they read as ends — so focus
+   * falls to its sibling, the only direction still worth pressing.
+   */
+  useLayoutEffect(() => {
+    const want = pendingFocus.current;
+    if (!want) return;
+    pendingFocus.current = null;
+    const pressed = moveButtons.current.get(moveKey(want.dir, want.entry));
+    const sibling = moveButtons.current.get(moveKey(want.dir === -1 ? 1 : -1, want.entry));
+    const target = pressed && !pressed.disabled ? pressed : sibling;
+    target?.focus();
+  }, [arranged]);
+
+  // Keyboard: the number keys pick an option, then 1-3 grade. Enter advances.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       const typing = document.activeElement?.tagName === 'INPUT';
       if (!revealed) {
         // While the bonus round is up the options are not on screen, so the
         // number keys must not reach behind it and answer for you.
-        if (item.kind === 'mcq' && !bonusOpen && /^[1-4]$/.test(e.key)) {
+        // As many number keys as there are options: hard renders six, and a
+        // key badge printed on a choice that no key answers is a small lie.
+        if (item.kind === 'mcq' && !bonusOpen && /^[1-9]$/.test(e.key)) {
           const opt = options[Number(e.key) - 1];
           if (opt) { e.preventDefault(); choose(opt); }
         }
@@ -202,6 +345,22 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
       </div>
 
       <p className="q-prompt">{item.prompt}</p>
+
+      {offersHint && !revealed && !bonusOpen && (
+        <div style={{ marginBottom: 12 }}>
+          <button
+            className="btn sm"
+            onClick={() => setHintOpen(!hintOpen)}
+            aria-expanded={hintOpen}
+            title="Shows the explanation before you answer"
+          >
+            {hintOpen ? 'Hide hint' : 'Show a hint'}
+          </button>
+          {hintOpen && (
+            <p className="tiny muted" style={{ margin: '8px 0 0' }}>{item.explain}</p>
+          )}
+        </div>
+      )}
 
       {bonusOpen && (
         <div>
@@ -273,21 +432,62 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
         <div>
           <ul className="order-list">
             {arranged.map((entry, i) => {
-              const cls = !revealed ? '' : correctIndex[entry] === i ? ' correct' : ' wrong';
+              const right = correctIndex[entry] === i;
+              const cls = !revealed ? '' : right ? ' correct' : ' wrong';
               return (
                 <li key={entry} className={`order-item${cls}`}>
                   <span className="num">{i + 1}</span>
                   <span>{entry}</span>
+                  {/* The verdict for this row in a second channel (#38). The
+                      tint and the border said it in colour alone — and in the
+                      one pair of colours, red against green, most likely to
+                      arrive as two identical greys. `role="img"` with a label
+                      is what carries it to a screen reader; the glyph is what
+                      carries it to everyone else. A <b> rather than a <span>
+                      keeps it out of the row's label text. */}
+                  {revealed && (
+                    <b
+                      className="mark"
+                      role="img"
+                      aria-label={right ? 'Right position' : 'Wrong position'}
+                    >
+                      {right ? '✓' : '✗'}
+                    </b>
+                  )}
                   {!revealed && (
                     <span className="moves">
-                      <button onClick={() => move(i, -1)} disabled={i === 0} aria-label="Move up">↑</button>
-                      <button onClick={() => move(i, 1)} disabled={i === arranged.length - 1} aria-label="Move down">↓</button>
+                      <button
+                        ref={(el) => {
+                          moveButtons.current.set(moveKey(-1, entry), el);
+                        }}
+                        onClick={() => move(i, -1)}
+                        disabled={i === 0}
+                        aria-label="Move up"
+                      >
+                        ↑
+                      </button>
+                      <button
+                        ref={(el) => {
+                          moveButtons.current.set(moveKey(1, entry), el);
+                        }}
+                        onClick={() => move(i, 1)}
+                        disabled={i === arranged.length - 1}
+                        aria-label="Move down"
+                      >
+                        ↓
+                      </button>
                     </span>
                   )}
                 </li>
               );
             })}
           </ul>
+          {/* Mounted empty and left mounted, because a live region that is
+              inserted with its text already in it is announced by roughly half
+              the screen readers that exist. `move` writes the sentence; every
+              other render leaves it exactly as it was, which is what keeps
+              this from narrating the whole card (#38). */}
+          <p className="sr-only" aria-live="polite">{orderNote}</p>
           {!revealed && (
             <div className="row" style={{ marginTop: 12 }}>
               <button className="btn primary" onClick={submitOrder}>Check order</button>
@@ -298,13 +498,30 @@ export default function QuestionCard({ item, onGrade, starred, onToggleStar, cou
 
       {revealed && (
         <div className={`feedback ${wasCorrect ? 'correct' : 'wrong'}`}>
-          <strong>{wasCorrect ? 'Correct' : 'Not quite'}</strong>
-          {!wasCorrect && (
-            <div style={{ marginTop: 4 }}>
-              Answer: <strong>{item.kind === 'order' ? (item.sequence ?? []).join(' → ') : item.answer}</strong>
-            </div>
-          )}
-          {item.explain && <div className="why">{item.explain}</div>}
+          {/*
+            The verdict, announced (#38).
+
+            "Correct" and "Not quite" arrived silently: the block is inserted
+            after the answer is in, and an insertion is not a change any screen
+            reader is watching for. `role="status"` is the polite kind — it
+            waits for a gap rather than cutting across whatever is being read.
+
+            Scoped to the verdict and the reason, with the grade buttons left
+            outside it deliberately: they are the next thing to *do*, not part
+            of the news, and an atomic region containing them would read out
+            "Hard, see it more often, Ok, normal pace…" every time. It cannot
+            fire twice per card either — the block exists only once `revealed`,
+            and nothing after that edits it.
+          */}
+          <div role="status">
+            <strong>{wasCorrect ? 'Correct' : 'Not quite'}</strong>
+            {!wasCorrect && (
+              <div style={{ marginTop: 4 }}>
+                Answer: <strong>{item.kind === 'order' ? (item.sequence ?? []).join(' → ') : item.answer}</strong>
+              </div>
+            )}
+            {item.explain && <div className="why">{item.explain}</div>}
+          </div>
 
           <div className="row" style={{ marginTop: 14 }}>
             {bonusEarned ? (

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -58,7 +58,7 @@ export const copy = {
    * the mechanism, and all three stay on screen at once — a reader choosing
    * between them needs to compare them, not discover them one at a time.
    *
-   * Those notes were rewritten in #38 because they had gone stale: they still
+   * Those notes were rewritten in #40 because they had gone stale: they still
    * described a setting that only moved wrong answers around, while the control
    * had quietly grown three more effects — how many options a question offers,
    * whether it asks for free recall first, and how new material is introduced.
@@ -96,7 +96,7 @@ export const copy = {
     },
 
     /**
-     * The follow-the-plan switch (#38).
+     * The follow-the-plan switch (#40).
      *
      * The note has one job the help line cannot do: say what happens when the
      * phase runs dry. A reader who thinks a calendar can lock them out of

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -54,11 +54,17 @@ export const copy = {
    * The settings panel (#36).
    *
    * Difficulty is the reason this copy has to work hard: "Easy / Medium / Hard"
-   * says nothing about *what* changes, and what changes here is where a
-   * question's wrong options are drawn from. So every level carries a sentence
-   * describing the mechanism, and all three stay on screen at once — a reader
-   * choosing between them needs to compare them, not discover them one at a
-   * time.
+   * says nothing about *what* changes. So every level carries a note describing
+   * the mechanism, and all three stay on screen at once — a reader choosing
+   * between them needs to compare them, not discover them one at a time.
+   *
+   * Those notes were rewritten in #38 because they had gone stale: they still
+   * described a setting that only moved wrong answers around, while the control
+   * had quietly grown three more effects — how many options a question offers,
+   * whether it asks for free recall first, and how new material is introduced.
+   * Copy that promises less than the code does is the same defect as copy that
+   * promises more; both leave the reader choosing blind. The figures below are
+   * the ones in lib/difficulty.ts (`DIFFICULTY_SPEC`) and have to move with it.
    */
   settings: {
     display: {
@@ -72,21 +78,41 @@ export const copy = {
       heading: 'Difficulty',
       /** accessible name for the Easy/Medium/Hard switch */
       label: 'Default difficulty',
-      help: 'Difficulty decides where a question’s wrong answers come from, and which cards the review queue puts in front of you. It takes effect on the next question you see.',
+      help: 'Difficulty changes four things: where a question’s wrong answers come from, how many options you are offered, whether a reference has to be named from memory first, and how new material is introduced. It takes effect on the next question you see.',
       options: {
         easy: {
           label: 'Easy',
-          note: 'Wrong answers can be drawn from anywhere in the canon, so the right one usually stands out on sight. The queue keeps bringing back the cards you already answer well.',
+          note: 'Three options, with the wrong two drawn from anywhere in the canon — usually wrong on sight. References are never asked from memory, and the explanation is offered as a hint before you answer. New material walks the canon in order, a little at a time.',
         },
         medium: {
           label: 'Medium',
-          note: 'Wrong answers come from books near the answer’s own, and never cross between the Old and New Testaments. This is how the trainer has always worked.',
+          note: 'Four options, with the wrong three drawn from books near the answer’s own and never across the Old/New Testament seam. A reference asks you to name it from memory before the choices appear. New material is interleaved. This is how the trainer has always worked.',
         },
         hard: {
           label: 'Hard',
-          note: 'Wrong answers come only from the same book, so nothing is given away by context. The queue spends most of its time on whatever you keep missing.',
+          note: 'Six options, drawn as close to the answer as the question allows — the same book where there is one, canonical neighbours for book order, the same era or family for people. References are always named from memory first, with no hint. New material comes from anywhere in the current scope in an unpredictable order, half again as much of it, and a card you miss does not come back until tomorrow.',
         },
       },
+    },
+
+    /**
+     * The follow-the-plan switch (#38).
+     *
+     * The note has one job the help line cannot do: say what happens when the
+     * phase runs dry. A reader who thinks a calendar can lock them out of
+     * studying will turn this off and never turn it back on, so the widening
+     * has to be stated up front rather than discovered.
+     */
+    followPlan: {
+      heading: 'Follow the study plan',
+      /** accessible name for the On/Off switch */
+      label: 'Follow the study plan',
+      help: 'Your daily review draws from whichever phase the plan is currently in, rather than from the whole bank at once. Quizzes are unaffected — they still cover whatever you point them at.',
+      options: { on: 'On', off: 'Off' },
+      note: 'The plan works in order — the frame first, then the Old Testament, then the New, then the timeline and mixed review — and this keeps the daily queue inside it. When there is not enough left in the current phase to fill a session, the queue quietly widens to the rest of the bank rather than telling you there is nothing to study.',
+      /** Names the phase the queue is currently drawn from, on the review screen. */
+      activeOn: (phaseName: string) => `Following the study plan: ${phaseName}.`,
+      studyEverything: 'Study everything instead',
     },
 
     study: {

--- a/src/data/books.ts
+++ b/src/data/books.ts
@@ -1245,7 +1245,7 @@ export const TOTAL_CHAPTERS = BOOKS.reduce((n, b) => n + b.chapters, 0); // 1189
  * makes a book-order question hard is *canonical distance*: Ezra against
  * Nehemiah, Esther and Chronicles is a real question; Ezra against Matthew is
  * a free point. So this pool crosses the seam on purpose, and tightens by
- * position instead (#38).
+ * position instead (#40).
  */
 export function neighborBooks(bookId: string, span: number): Book[] {
   const book = BOOKS_BY_ID[bookId];

--- a/src/data/books.ts
+++ b/src/data/books.ts
@@ -1234,3 +1234,41 @@ export function isPropheticBook(bookId: string): boolean {
 
 /** Chapter totals — useful as a self-check that the data stayed intact. */
 export const TOTAL_CHAPTERS = BOOKS.reduce((n, b) => n + b.chapters, 0); // 1189
+
+/**
+ * Books within `span` canonical positions of `bookId`, excluding it.
+ *
+ * Book-order questions are the one place the Testament seam is not the right
+ * fence. "Which book immediately follows Malachi?" has a New Testament answer
+ * to an Old Testament question, so scoping those options by Testament would
+ * make the correct one identifiable without knowing the canon at all. What
+ * makes a book-order question hard is *canonical distance*: Ezra against
+ * Nehemiah, Esther and Chronicles is a real question; Ezra against Matthew is
+ * a free point. So this pool crosses the seam on purpose, and tightens by
+ * position instead (#38).
+ */
+export function neighborBooks(bookId: string, span: number): Book[] {
+  const book = BOOKS_BY_ID[bookId];
+  if (!book) return [];
+  return BOOKS.filter(
+    (b) => b.id !== bookId && Math.abs(b.order - book.order) <= span,
+  );
+}
+
+/**
+ * Books at least `span` canonical positions away from `bookId` — the mirror of
+ * `neighborBooks`, and what makes an easy book-order question easy: every wrong
+ * option sits in a different stretch of the canon entirely.
+ */
+export function distantBooks(bookId: string, span: number): Book[] {
+  const book = BOOKS_BY_ID[bookId];
+  if (!book) return BOOKS;
+  return BOOKS.filter((b) => b.id !== bookId && Math.abs(b.order - book.order) > span);
+}
+
+/** Every book in the same Testament as `bookId`, excluding it. */
+export function sameTestamentBooks(bookId: string): Book[] {
+  const book = BOOKS_BY_ID[bookId];
+  if (!book) return BOOKS;
+  return BOOKS.filter((b) => b.id !== bookId && b.testament === book.testament);
+}

--- a/src/data/plan.ts
+++ b/src/data/plan.ts
@@ -103,7 +103,7 @@ export interface PlannedWeek {
  *
  * The `new Date()` default stays for the sake of a bare "what would a plan
  * starting today look like?" call, but it is no longer what the app relies on
- * (#38): every caller passes the member's stored anchor, because a schedule
+ * (#40): every caller passes the member's stored anchor, because a schedule
  * that re-anchors to today on each render is a schedule whose week 1 never
  * ends. Prefer `currentWeek` / `currentPhase`, which require the anchor.
  */
@@ -157,7 +157,7 @@ export function buildSchedule(examISO: string, startDate = new Date()): PlannedW
 /**
  * The week the calendar is currently sitting in, clamped to the schedule's ends.
  *
- * Two views computed this inline and identically (#38) — Dashboard to name the
+ * Two views computed this inline and identically (#40) — Dashboard to name the
  * phase on its hero card, Plan to mark a row `now` — and a third caller then
  * arrived in Review, which is where a duplicated definition of "today" stops
  * being a tidiness problem and starts being a correctness one: the daily queue
@@ -196,7 +196,7 @@ export function currentWeek(
 ): PlannedWeek | null {
   // A hand-edited or imported `planStart` can be junk; an Invalid Date here
   // would make every week boundary NaN and every comparison false, so fall
-  // back to `now` — the pre-#38 behaviour, which is at least well-defined.
+  // back to `now` — the pre-#40 behaviour, which is at least well-defined.
   const parsed = new Date(`${planStartISO}T00:00:00`);
   const schedule = buildSchedule(examISO, Number.isNaN(parsed.getTime()) ? now : parsed);
   if (schedule.length === 0) return null;

--- a/src/data/plan.ts
+++ b/src/data/plan.ts
@@ -97,7 +97,16 @@ export interface PlannedWeek {
   label: string;
 }
 
-/** Slice the calendar between now and the exam into weeks, assigned by phase weight. */
+/**
+ * Slice the calendar between `startDate` and the exam into weeks, assigned by
+ * phase weight.
+ *
+ * The `new Date()` default stays for the sake of a bare "what would a plan
+ * starting today look like?" call, but it is no longer what the app relies on
+ * (#38): every caller passes the member's stored anchor, because a schedule
+ * that re-anchors to today on each render is a schedule whose week 1 never
+ * ends. Prefer `currentWeek` / `currentPhase`, which require the anchor.
+ */
 export function buildSchedule(examISO: string, startDate = new Date()): PlannedWeek[] {
   const exam = new Date(`${examISO}T23:59:59`);
   const start = new Date(startDate);
@@ -143,4 +152,78 @@ export function buildSchedule(examISO: string, startDate = new Date()): PlannedW
   });
 
   return weeks.filter((w) => w.start <= exam);
+}
+
+/**
+ * The week the calendar is currently sitting in, clamped to the schedule's ends.
+ *
+ * Two views computed this inline and identically (#38) — Dashboard to name the
+ * phase on its hero card, Plan to mark a row `now` — and a third caller then
+ * arrived in Review, which is where a duplicated definition of "today" stops
+ * being a tidiness problem and starts being a correctness one: the daily queue
+ * and the schedule it claims to follow have to agree on which week it is.
+ *
+ * `planStartISO` is required rather than defaulted, and that is the whole
+ * repair. The old shape let the anchor fall back to `new Date()`, which meant
+ * every call rebuilt the schedule starting today, today always landed in week
+ * 1, and the plan could never advance past Phase 1 — invisible while the plan
+ * was decorative, and a hard cap on what anyone could study once the review
+ * began filtering on it. An optional anchor would let any future caller
+ * reintroduce exactly that bug in silence; a required one makes the compiler
+ * ask. Callers get the value from `planStartOf(store)` in lib/store-ops.ts.
+ *
+ * The window runs to the day *after* `end`, which is what both views already
+ * did: `end` is midnight at the head of the last day, so without the extra day
+ * the final day of every week would belong to no week at all.
+ *
+ * Now that the anchor is a stored fact, `now` can genuinely sit outside the
+ * schedule, so both ends are clamped rather than answered with null:
+ *
+ * - **Before the first week** (an anchor set in the future): the first week.
+ *   The plan has not started; Phase 1 is still what it is asking for.
+ * - **Past the last week** (an anchor far enough back that the runway has run
+ *   out): the last week. Returning nothing here would be the worst answer
+ *   available — the member is out of time, and Phase 5's "no new material,
+ *   mixed review" is precisely the advice for that.
+ *
+ * Null is left for the one case with no week to name at all: an empty
+ * schedule, which happens only when the anchor is itself past the exam date.
+ */
+export function currentWeek(
+  examISO: string,
+  planStartISO: string,
+  now = new Date(),
+): PlannedWeek | null {
+  // A hand-edited or imported `planStart` can be junk; an Invalid Date here
+  // would make every week boundary NaN and every comparison false, so fall
+  // back to `now` — the pre-#38 behaviour, which is at least well-defined.
+  const parsed = new Date(`${planStartISO}T00:00:00`);
+  const schedule = buildSchedule(examISO, Number.isNaN(parsed.getTime()) ? now : parsed);
+  if (schedule.length === 0) return null;
+
+  const first = schedule[0];
+  const last = schedule[schedule.length - 1];
+  if (now < first.start) return first;
+  const window = (w: PlannedWeek) => new Date(w.end.getTime() + 86_400_000);
+  if (now > window(last)) return last;
+  return schedule.find((w) => now >= w.start && now <= window(w)) ?? last;
+}
+
+/**
+ * The phase that week belongs to — what the study plan is asking of you today.
+ *
+ * Total, deliberately: there is no date on which the honest answer is "no
+ * phase". The two ways to fall off the schedule both land on Phase 5, which is
+ * why the fallback below is the last phase and not null:
+ *
+ * - The runway ran out — handled by `currentWeek`'s clamp above.
+ * - The schedule is empty because the anchor is *after* the exam date, so
+ *   `buildSchedule` filters every week away. That is a plan with no time in it
+ *   at all: same situation, same answer.
+ *
+ * Callers that want "no filtering" (Review when the setting is off) express it
+ * by not calling this, rather than by hoping for a null.
+ */
+export function currentPhase(examISO: string, planStartISO: string, now = new Date()): Phase {
+  return currentWeek(examISO, planStartISO, now)?.phase ?? PHASES[PHASES.length - 1];
 }

--- a/src/lib/difficulty.ts
+++ b/src/lib/difficulty.ts
@@ -1,0 +1,112 @@
+/**
+ * What each difficulty setting actually changes.
+ *
+ * Before this file the setting had two effects: it swapped the wrong-option set
+ * on the ~30% of items that carried alternates, and it leaned the review queue
+ * by ease. Everything else — how many options a question offers, whether it
+ * asks for free recall first, and the order new material is introduced in —
+ * was identical at all three settings, which is why `hard` did not feel hard
+ * and `easy` did not feel easy.
+ *
+ * The rule that governs every dial below: **the item bank stays
+ * difficulty-blind**. Item ids are the key SRS history is stored under, so a
+ * bank that generated different items per setting would detach every card the
+ * moment someone touched the control. Difficulty therefore lives entirely in
+ * (a) which of an item's pre-baked option sets is rendered, (b) how much of it
+ * is rendered, and (c) which cards get selected and in what order.
+ */
+import type { Difficulty } from '../data/types';
+
+export interface DifficultySpec {
+  /**
+   * Wrong options offered alongside the answer.
+   *
+   * Fewer choices is straightforwardly easier — a 3-option question is a coin
+   * flip after one elimination — so this is the single cheapest honest dial in
+   * the whole system, and it costs nothing in item stability.
+   */
+  wrongOptions: number;
+  /**
+   * Whether a question whose answer is a scripture reference opens with a
+   * chance to name it from memory before any options appear (#14).
+   *
+   * Free recall is strictly harder than recognition, so `easy` skips straight
+   * to the choices and `hard` always asks first.
+   */
+  bonusRound: boolean;
+  /**
+   * How new cards are ordered as they are introduced.
+   *
+   * `canonical` walks the bank in generation order — Genesis first, straight
+   * through the canon. That is the right shape for a beginner building the
+   * frame, and it is exactly what made the trainer predictable at every other
+   * setting: you could tell what was coming next from where you were.
+   */
+  newOrder: 'canonical' | 'interleaved' | 'shuffled';
+  /**
+   * Which detail tiers new material is drawn from first. 1 = foundational,
+   * 3 = fine detail. `hard` stops protecting you from tier 3.
+   */
+  tierBias: 'foundation-first' | 'balanced' | 'detail-first';
+  /**
+   * Multiplier on the configured new-card limit. Easy introduces less at once
+   * and spends the session consolidating; hard pushes more new ground.
+   */
+  newLimitFactor: number;
+  /**
+   * How hard the queue leans on per-card ease when it cuts to the session
+   * limit, in days of borrowed urgency. Signed by the setting: `hard` pulls
+   * forward the cards you keep fumbling, `easy` the ones you nearly have.
+   */
+  easeLeanDays: number;
+  /** Whether missed cards come back inside the same session. */
+  requeueMissed: boolean;
+  /** Whether the answer's explanation is offered before answering, as a hint. */
+  hintBeforeAnswer: boolean;
+}
+
+export const DIFFICULTY_SPEC: Record<Difficulty, DifficultySpec> = {
+  easy: {
+    wrongOptions: 2,
+    bonusRound: false,
+    newOrder: 'canonical',
+    tierBias: 'foundation-first',
+    newLimitFactor: 0.6,
+    easeLeanDays: -3,
+    requeueMissed: true,
+    hintBeforeAnswer: true,
+  },
+  medium: {
+    wrongOptions: 3,
+    bonusRound: true,
+    newOrder: 'interleaved',
+    tierBias: 'balanced',
+    newLimitFactor: 1,
+    easeLeanDays: 0,
+    requeueMissed: true,
+    hintBeforeAnswer: false,
+  },
+  hard: {
+    wrongOptions: 5,
+    bonusRound: true,
+    newOrder: 'shuffled',
+    tierBias: 'detail-first',
+    newLimitFactor: 1.5,
+    easeLeanDays: 3,
+    requeueMissed: false,
+    hintBeforeAnswer: false,
+  },
+};
+
+export function specFor(d: Difficulty | undefined): DifficultySpec {
+  return DIFFICULTY_SPEC[d ?? 'medium'];
+}
+
+/**
+ * How many wrong options a generator has to bake so that every setting can be
+ * served from one difficulty-blind bank: the largest number any setting asks
+ * for. Rendering slices down; it never has to reach for more.
+ */
+export const MAX_WRONG_OPTIONS = Math.max(
+  ...Object.values(DIFFICULTY_SPEC).map((s) => s.wrongOptions),
+);

--- a/src/lib/distractors.ts
+++ b/src/lib/distractors.ts
@@ -85,7 +85,7 @@ export function distractorSets(
 ): DistractorSets {
   // `hard` asks for the widest set any setting renders, not `n`: the render
   // site slices down per setting, and a hard card that could only fill three
-  // slots would show fewer choices than medium — easier, not harder (#38).
+  // slots would show fewer choices than medium — easier, not harder (#40).
   return scopedSets(answer, seed, {
     medium: nearbyPool(bookId, extract, answer, n),
     easy: [() => canonPool(extract, answer)],
@@ -106,7 +106,7 @@ export function distractorSets(
  * silently yields a short pool does not make a question harder — it makes it
  * *shorter*, and a three-choice question is easier than a six-choice one. The
  * widening is the guarantee that a `hard` card is never accidentally the
- * easiest card on screen (#38).
+ * easiest card on screen (#40).
  */
 export function layeredPool(
   chain: readonly (() => string[])[],

--- a/src/lib/distractors.ts
+++ b/src/lib/distractors.ts
@@ -15,6 +15,7 @@
 import { BOOKS_BY_ID, canonPool, nearbyPool } from '../data/books';
 import type { Book, Difficulty } from '../data/types';
 import { pickDistractors } from './rng';
+import { MAX_WRONG_OPTIONS } from './difficulty';
 
 /**
  * How tight `hard` is allowed to be for this question.
@@ -82,11 +83,90 @@ export function distractorSets(
   hardScope: HardScope,
   n = 3,
 ): DistractorSets {
-  return {
-    distractors: pickDistractors(nearbyPool(bookId, extract, answer, n), answer, n, seed),
-    distractorsBy: {
-      easy: pickDistractors(canonPool(extract, answer), answer, n, `${seed}:easy`),
-      hard: pickDistractors(hardPool(bookId, extract, answer, n, hardScope), answer, n, `${seed}:hard`),
-    },
-  };
+  // `hard` asks for the widest set any setting renders, not `n`: the render
+  // site slices down per setting, and a hard card that could only fill three
+  // slots would show fewer choices than medium — easier, not harder (#38).
+  return scopedSets(answer, seed, {
+    medium: nearbyPool(bookId, extract, answer, n),
+    easy: [() => canonPool(extract, answer)],
+    hard: [
+      () => hardPool(bookId, extract, answer, MAX_WRONG_OPTIONS, hardScope),
+      () => hardPool(bookId, extract, answer, n, hardScope),
+      () => nearbyPool(bookId, extract, answer, MAX_WRONG_OPTIONS),
+    ],
+  }, n);
+}
+
+/**
+ * Walk `chain` from its tightest pool outward and return the first that can
+ * supply `n` distinct options other than `answer`; if none can, return the
+ * widest.
+ *
+ * Every scoped pool in the app needs this shape, because tightness that
+ * silently yields a short pool does not make a question harder — it makes it
+ * *shorter*, and a three-choice question is easier than a six-choice one. The
+ * widening is the guarantee that a `hard` card is never accidentally the
+ * easiest card on screen (#38).
+ */
+export function layeredPool(
+  chain: readonly (() => string[])[],
+  answer: string,
+  n: number,
+): string[] {
+  let widest: string[] = [];
+  for (const build of chain) {
+    const pool = [...new Set(build())].filter((s) => s && s !== answer);
+    if (pool.length > widest.length) widest = pool;
+    if (pool.length >= n) return pool;
+  }
+  return widest;
+}
+
+/**
+ * The one entry point every generator uses to bake its three option sets.
+ *
+ * `medium` is passed as a ready-made pool because it has to stay byte-identical
+ * to what the generator produced before — `Item.distractors` is what validate.ts,
+ * the content-contract tests and every existing user's rendered card read, and
+ * item ids are the key SRS history is stored under. `easy` and `hard` are
+ * chains: `hard` tightest-first, widening only when the tight pool cannot fill
+ * the card; `easy` widest-first, because the whole point of easy is options
+ * that are wrong on sight.
+ *
+ * Each set gets its own seed suffix. Without that a wider pool reshuffled by
+ * the same seed lands on nearly the same handful of strings, and the three
+ * settings become three names for one question.
+ */
+export function scopedSets(
+  answer: string,
+  seed: string,
+  pools: {
+    medium: readonly string[];
+    easy: readonly (() => string[])[];
+    hard: readonly (() => string[])[];
+  },
+  n = 3,
+): DistractorSets {
+  const distractors = pickDistractors(pools.medium, answer, n, seed);
+  const floor = distractors.length;
+  const easyPool = layeredPool(pools.easy, answer, Math.max(floor, n));
+  const hardPool = layeredPool(pools.hard, answer, MAX_WRONG_OPTIONS);
+
+  const easy = pickDistractors(easyPool, answer, Math.max(floor, n), `${seed}:easy`);
+  let hard = pickDistractors(hardPool, answer, MAX_WRONG_OPTIONS, `${seed}:hard`);
+
+  // The thinness guard. A hard set shorter than the medium one would render
+  // fewer choices than medium does, inverting the setting. Top it up from the
+  // wider pools rather than shipping a three-choice "hard" question.
+  if (hard.length < floor) {
+    const topUp = pickDistractors(
+      [...hardPool, ...easyPool, ...pools.medium],
+      answer,
+      MAX_WRONG_OPTIONS,
+      `${seed}:hard:topup`,
+    );
+    hard = [...new Set([...hard, ...topUp])].slice(0, MAX_WRONG_OPTIONS);
+  }
+
+  return { distractors, distractorsBy: { easy, hard } };
 }

--- a/src/lib/generate-detail.ts
+++ b/src/lib/generate-detail.ts
@@ -1,7 +1,7 @@
-import { BOOKS, isPropheticBook } from '../data/books';
+import { BOOKS, BOOKS_BY_ID, booksNear, isPropheticBook, sameTestamentBooks } from '../data/books';
 import { DETAILS, type BookDetail, type DetailEvent } from '../data/details';
-import type { Item } from '../data/types';
-import { distractorSets } from './distractors';
+import type { Book, Item } from '../data/types';
+import { distractorSets, scopedSets } from './distractors';
 import { pickDistractors, seededShuffle } from './rng';
 
 const bookName = new Map(BOOKS.map((b) => [b.id, b.name]));
@@ -16,6 +16,87 @@ const allNumberValues = DETAILS.flatMap((d) => d.numbers?.map((n) => n.value) ??
 const allPurposes = DETAILS.map((d) => d.purpose);
 const allAudiences = [...new Set(DETAILS.map((d) => d.audience))];
 const allWritten = [...new Set(DETAILS.map((d) => d.written))];
+
+/**
+ * The rings every hard chain in this file walks, tightest first (#38).
+ *
+ * Until now the raw `pickDistractors` sites below drew from one of the
+ * canon-wide arrays above (or, at best, from the whole book), so the setting
+ * changed how *many* wrong options a card showed but never how close they sat
+ * to the answer — "hard" was six canon-wide strangers where medium was four.
+ * These rings are what the scoped chains widen through: the book itself, then
+ * its division, then its Testament, never across the seam (the same fence
+ * `nearbyPool` keeps, for the same reason — a Colossians option against a
+ * Leviticus question is a different subject, not a harder one).
+ *
+ * Each ring is a strict superset of the one before, which is what makes
+ * `layeredPool`'s widening monotonic. `booksNear(id, 0)` already contains the
+ * book; `sameTestamentBooks` deliberately does not, so it is added back here.
+ */
+function ownRing(bookId: string): Book[] {
+  const b = BOOKS_BY_ID[bookId];
+  return b ? [b] : [];
+}
+
+function divisionRing(bookId: string): Book[] {
+  return booksNear(bookId, 0);
+}
+
+function testamentRing(bookId: string): Book[] {
+  return [...ownRing(bookId), ...sameTestamentBooks(bookId)];
+}
+
+/** One field out of every detail record in a ring, absent values dropped. */
+function fromDetails(
+  books: Book[],
+  extract: (d: BookDetail) => readonly (string | undefined)[],
+): string[] {
+  return books.flatMap((b) => {
+    const d = detailByBook.get(b.id);
+    return d ? extract(d).filter((s): s is string => !!s) : [];
+  });
+}
+
+/**
+ * The hard chain for anything that lives *inside* a book — its cast, their
+ * deeds, the people and places its episodes name, its numbers.
+ *
+ * The book's own record is the tightest honest pool here: telling Aaron from
+ * Miriam is a Numbers question, telling Aaron from Habakkuk is not a question
+ * at all. Any per-question exclusion belongs inside `extract` rather than
+ * after the fact, so that a ring which cannot actually offer enough options is
+ * seen as short and widened past, instead of looking full and coming up empty.
+ */
+function insideChain(
+  bookId: string,
+  extract: (d: BookDetail) => readonly (string | undefined)[],
+): (() => string[])[] {
+  return [
+    () => fromDetails(ownRing(bookId), extract),
+    () => fromDetails(divisionRing(bookId), extract),
+    () => fromDetails(testamentRing(bookId), extract),
+  ];
+}
+
+/**
+ * The hard chain for whole-book fields — purpose, audience, date, place of
+ * writing.
+ *
+ * There is no own-book ring on purpose: a book has exactly one purpose and it
+ * is the answer, so the tightest pool that can exist is the surrounding
+ * division. That is still a real tightening. "When was Nahum written?" against
+ * the other Minor Prophets' dates is a date question; against the whole canon's
+ * it is an Old-Testament-or-New question, which the prompt already gave away.
+ */
+function aboutChain(
+  bookId: string,
+  extract: (d: BookDetail) => readonly (string | undefined)[],
+): (() => string[])[] {
+  return [
+    () => fromDetails(divisionRing(bookId), extract),
+    () => fromDetails(testamentRing(bookId), extract),
+  ];
+}
 
 function ref(d: BookDetail, r: string): string {
   return `${bookName.get(d.book) ?? d.book} ${r}`;
@@ -145,11 +226,24 @@ function eventItems(d: BookDetail): Item[] {
     if (scoped.length > 0) {
       const answer = scoped[0];
       const others = allFigureNames.filter((n) => !e.who.includes(n));
+      // Everyone the episode actually names is barred from *every* tier, not
+      // just from `others`. A tighter pool that let a genuine participant
+      // through would be offering a second right answer, and validate.ts only
+      // ever compares options against `answer` itself, so nothing downstream
+      // would catch it (#38).
+      const notPresent = (n: string) => !e.who.includes(n);
       items.push({
         id: `det-ev-who-${key}`, kind: 'mcq', topic: 'people', tier: 2, book: d.book,
         prompt: `Who is involved in this? "${e.what}"`,
         answer,
-        distractors: pickDistractors(others, answer, 3, `evwho-${key}`),
+        // Medium has always been every figure in the canon, which makes this a
+        // which-book question in disguise. Hard offers the other people this
+        // book's own episodes put on stage, so it asks who did *this* (#38).
+        ...scopedSets(answer, `evwho-${key}`, {
+          medium: others,
+          easy: [() => others],
+          hard: insideChain(d.book, (x) => x.events.flatMap((y) => y.who).filter(notPresent)),
+        }),
         explain: `${e.name}, ${ref(d, e.ref)}${e.who.length > 1 ? ` — also involved: ${e.who.filter((w) => w !== answer).join(', ')}` : ''}.`,
       });
     }
@@ -161,7 +255,14 @@ function eventItems(d: BookDetail): Item[] {
         id: `det-ev-where-${key}`, kind: 'mcq', topic: 'places', tier: 3, book: d.book,
         prompt: `Where does this take place? "${e.what}"`,
         answer: e.where,
-        distractors: pickDistractors(places, e.where, 3, `evwhere-${key}`),
+        // Hard offers the other places this book's own episodes happen: Sinai
+        // against Kadesh, Nebo and the Red Sea is a where-in-Exodus question;
+        // Sinai against Patmos and Antioch is a which-Testament one (#38).
+        ...scopedSets(e.where, `evwhere-${key}`, {
+          medium: places,
+          easy: [() => places],
+          hard: insideChain(d.book, (x) => x.events.map((y) => y.where)),
+        }),
         explain: `${e.name} — ${ref(d, e.ref)}.`,
       });
     }
@@ -239,9 +340,15 @@ function figureItems(d: BookDetail): Item[] {
       id: `det-fig-did-${key}`, kind: 'mcq', topic: 'people', tier: 2, book: d.book,
       prompt: `In ${name}, what does ${f.name} do?`,
       answer: f.did,
-      distractors: pickDistractors(
-        ownDeeds.length >= 6 ? ownDeeds : allFigureDeeds, f.did, 3, `figd-${key}`,
-      ),
+      // Medium keeps its old rule exactly — this book's deeds when the cast is
+      // big enough, the canon's otherwise. Hard always starts from this book,
+      // so the small-cast books stop pitting a Ruth deed against a Revelation
+      // one merely because Ruth lists fewer than six figures (#38).
+      ...scopedSets(f.did, `figd-${key}`, {
+        medium: ownDeeds.length >= 6 ? ownDeeds : allFigureDeeds,
+        easy: [() => allFigureDeeds],
+        hard: insideChain(d.book, (x) => x.figures.map((y) => y.did)),
+      }),
       explain: f.ref ? `See ${f.ref}.` : undefined,
     });
 
@@ -251,7 +358,15 @@ function figureItems(d: BookDetail): Item[] {
         id: `det-fig-who-${key}`, kind: 'mcq', topic: 'people', tier: 3, book: d.book,
         prompt: `Who is this, in ${name}? "${f.did}"`,
         answer: f.name,
-        distractors: pickDistractors(d.figures.map((x) => x.name), f.name, 3, `figw-${key}`),
+        // Medium is already this book's own cast, so hard cannot sit tighter;
+        // what it adds is the extra two options. A four-figure book cannot fill
+        // six slots from its own list, and the chain widens to the division
+        // rather than let the hardest setting render the shortest card (#38).
+        ...scopedSets(f.name, `figw-${key}`, {
+          medium: d.figures.map((x) => x.name),
+          easy: [() => allFigureNames],
+          hard: insideChain(d.book, (x) => x.figures.map((y) => y.name)),
+        }),
         explain: f.ref,
       });
     }
@@ -275,9 +390,16 @@ function numberItems(d: BookDetail): Item[] {
       id: `det-num-${key}`, kind: 'mcq', topic: 'numbers', tier: 3, book: d.book,
       prompt: `${name} — ${n.of}?`,
       answer: n.value,
-      distractors: pickDistractors(
-        ownValues.length >= 5 ? ownValues : allNumberValues, n.value, 3, `num-${key}`,
-      ),
+      // `numbers` is the sparsest field in the detail layer — most books record
+      // none at all — so even the Testament ring often cannot reach six values
+      // and `scopedSets`' thinness guard tops the hard set up from the wider
+      // pools. That is the intended outcome: a genuinely scoped hard set where
+      // one exists, and a full card rather than a short one where it does not.
+      ...scopedSets(n.value, `num-${key}`, {
+        medium: ownValues.length >= 5 ? ownValues : allNumberValues,
+        easy: [() => allNumberValues],
+        hard: insideChain(d.book, (x) => (x.numbers ?? []).map((y) => y.value)),
+      }),
       explain: n.ref,
     });
   }
@@ -296,7 +418,15 @@ function frameItems(d: BookDetail): Item[] {
       id: `det-purpose-${d.book}`, kind: 'mcq', topic: 'summaries', tier: 2, book: d.book,
       prompt: `Why was ${name} written?`,
       answer: d.purpose,
-      distractors: pickDistractors(allPurposes, d.purpose, 3, `pur-${d.book}`),
+      // Only the prophets ask this (#9), and the prophets are exactly where a
+      // canon-wide pool gives the game away: "why was Joel written?" against
+      // Philemon and Leviticus answers itself. Hard keeps it among the other
+      // Minor Prophets, whose stated purposes genuinely overlap (#38).
+      ...scopedSets(d.purpose, `pur-${d.book}`, {
+        medium: allPurposes,
+        easy: [() => allPurposes],
+        hard: aboutChain(d.book, (x) => [x.purpose]),
+      }),
       explain: `Audience: ${d.audience}.`,
     });
 
@@ -304,7 +434,11 @@ function frameItems(d: BookDetail): Item[] {
       id: `det-audience-${d.book}`, kind: 'mcq', topic: 'summaries', tier: 3, book: d.book,
       prompt: `Who was ${name} written to?`,
       answer: d.audience,
-      distractors: pickDistractors(allAudiences, d.audience, 3, `aud-${d.book}`),
+      ...scopedSets(d.audience, `aud-${d.book}`, {
+        medium: allAudiences,
+        easy: [() => allAudiences],
+        hard: aboutChain(d.book, (x) => [x.audience]),
+      }),
       explain: d.purpose,
     });
   }
@@ -313,7 +447,15 @@ function frameItems(d: BookDetail): Item[] {
     id: `det-written-${d.book}`, kind: 'mcq', topic: 'timeline', tier: 3, book: d.book,
     prompt: `When was ${name} written?`,
     answer: d.written,
-    distractors: pickDistractors(allWritten, d.written, 3, `wr-${d.book}`),
+    // Dates are the clearest case for scoping: books in one division were
+    // written within decades of each other, so the division's dates are the
+    // options a reader actually has to weigh. The canon's span a millennium,
+    // which quietly turns this into an OT-or-NT question (#38).
+    ...scopedSets(d.written, `wr-${d.book}`, {
+      medium: allWritten,
+      easy: [() => allWritten],
+      hard: aboutChain(d.book, (x) => [x.written]),
+    }),
     explain: `${name}: ${d.purpose}.`,
   });
 
@@ -328,7 +470,19 @@ function frameItems(d: BookDetail): Item[] {
       id: `det-distinctive-${d.book}`, kind: 'mcq', topic: 'summaries', tier: 3, book: d.book,
       prompt: `Which book is this true of? "${d.distinctive}"`,
       answer: name,
-      distractors: pickDistractors(BOOKS.map((b) => b.name), name, 3, `dis-${d.book}`),
+      // The pool here is book names rather than a detail field, so this walks
+      // the rings directly instead of through `aboutChain`. Only prophetic
+      // books ask it, which means the tight ring is the other Major or Minor
+      // Prophets — the seventeen books #9 kept these questions for, and the one
+      // stretch of the canon where "which book is this?" is a real question.
+      ...scopedSets(name, `dis-${d.book}`, {
+        medium: BOOKS.map((b) => b.name),
+        easy: [() => BOOKS.map((b) => b.name)],
+        hard: [
+          () => divisionRing(d.book).map((b) => b.name),
+          () => testamentRing(d.book).map((b) => b.name),
+        ],
+      }),
       explain: d.purpose,
     });
   }
@@ -339,7 +493,15 @@ function frameItems(d: BookDetail): Item[] {
       id: `det-from-${d.book}`, kind: 'mcq', topic: 'places', tier: 3, book: d.book,
       prompt: `Where was ${name} written from?`,
       answer: d.writtenFrom,
-      distractors: pickDistractors(froms, d.writtenFrom, 3, `frm-${d.book}`),
+      // `writtenFrom` is recorded almost only for the Pauline epistles, so the
+      // division ring and the canon-wide pool are nearly the same handful of
+      // cities. The scoping is honest but thin here; the widening and the
+      // thinness guard are what keep the card full (#38).
+      ...scopedSets(d.writtenFrom, `frm-${d.book}`, {
+        medium: froms,
+        easy: [() => froms],
+        hard: aboutChain(d.book, (x) => [x.writtenFrom]),
+      }),
       explain: `${name}, ${d.written}.`,
     });
   }
@@ -374,11 +536,23 @@ function crossBookItems(): Item[] {
   const sample = seededShuffle(soloEvents, 'cross-who').slice(0, 60);
   for (const { d, e } of sample) {
     const answer = e.who[0];
+    // Same exclusion rule as the in-book who-question: nobody the episode
+    // actually involves may surface as a wrong option in any tier, or the card
+    // has two right answers.
+    const others = allFigureNames.filter((n) => !e.who.includes(n));
     items.push({
       id: `det-x-who-${d.book}-${slug(e.name)}`, kind: 'mcq', topic: 'people', tier: 3, book: d.book,
       prompt: `Who is at the center of this event: ${e.name}?`,
       answer,
-      distractors: pickDistractors(allFigureNames.filter((n) => !e.who.includes(n)), answer, 3, `xw-${d.book}-${e.name}`),
+      // This item is deliberately cross-book, so medium spans the canon. Hard
+      // narrows to the cast of the book the episode came from: the golden calf
+      // against Aaron, Joshua and Hur is a question about Exodus; against
+      // Nehemiah and Titus it is a question about the table of contents (#38).
+      ...scopedSets(answer, `xw-${d.book}-${e.name}`, {
+        medium: others,
+        easy: [() => others],
+        hard: insideChain(d.book, (x) => x.figures.map((y) => y.name).filter((n) => !e.who.includes(n))),
+      }),
       explain: `${ref(d, e.ref)} — ${e.what}`,
     });
   }

--- a/src/lib/generate-detail.ts
+++ b/src/lib/generate-detail.ts
@@ -276,7 +276,11 @@ function eventItems(d: BookDetail): Item[] {
         ...distractorSets(
           d.book,
           (x) => (detailByBook.get(x.id)?.events ?? []).map((y) => y.detail).filter((y): y is string => !!y),
-          e.detail, `evd-${key}`, 'division',
+          // The detail is a fact from *inside* one episode, so the tightest
+          // honest pool is the other details that book records — unlike
+          // "in which book does this happen?", where the answer is a book and
+          // the division is as tight as it can get.
+          e.detail, `evd-${key}`, 'book',
         ),
         explain: e.what,
       });

--- a/src/lib/generate-detail.ts
+++ b/src/lib/generate-detail.ts
@@ -18,7 +18,7 @@ const allAudiences = [...new Set(DETAILS.map((d) => d.audience))];
 const allWritten = [...new Set(DETAILS.map((d) => d.written))];
 
 /**
- * The rings every hard chain in this file walks, tightest first (#38).
+ * The rings every hard chain in this file walks, tightest first (#40).
  *
  * Until now the raw `pickDistractors` sites below drew from one of the
  * canon-wide arrays above (or, at best, from the whole book), so the setting
@@ -230,7 +230,7 @@ function eventItems(d: BookDetail): Item[] {
       // just from `others`. A tighter pool that let a genuine participant
       // through would be offering a second right answer, and validate.ts only
       // ever compares options against `answer` itself, so nothing downstream
-      // would catch it (#38).
+      // would catch it (#40).
       const notPresent = (n: string) => !e.who.includes(n);
       items.push({
         id: `det-ev-who-${key}`, kind: 'mcq', topic: 'people', tier: 2, book: d.book,
@@ -238,7 +238,7 @@ function eventItems(d: BookDetail): Item[] {
         answer,
         // Medium has always been every figure in the canon, which makes this a
         // which-book question in disguise. Hard offers the other people this
-        // book's own episodes put on stage, so it asks who did *this* (#38).
+        // book's own episodes put on stage, so it asks who did *this* (#40).
         ...scopedSets(answer, `evwho-${key}`, {
           medium: others,
           easy: [() => others],
@@ -257,7 +257,7 @@ function eventItems(d: BookDetail): Item[] {
         answer: e.where,
         // Hard offers the other places this book's own episodes happen: Sinai
         // against Kadesh, Nebo and the Red Sea is a where-in-Exodus question;
-        // Sinai against Patmos and Antioch is a which-Testament one (#38).
+        // Sinai against Patmos and Antioch is a which-Testament one (#40).
         ...scopedSets(e.where, `evwhere-${key}`, {
           medium: places,
           easy: [() => places],
@@ -347,7 +347,7 @@ function figureItems(d: BookDetail): Item[] {
       // Medium keeps its old rule exactly — this book's deeds when the cast is
       // big enough, the canon's otherwise. Hard always starts from this book,
       // so the small-cast books stop pitting a Ruth deed against a Revelation
-      // one merely because Ruth lists fewer than six figures (#38).
+      // one merely because Ruth lists fewer than six figures (#40).
       ...scopedSets(f.did, `figd-${key}`, {
         medium: ownDeeds.length >= 6 ? ownDeeds : allFigureDeeds,
         easy: [() => allFigureDeeds],
@@ -365,7 +365,7 @@ function figureItems(d: BookDetail): Item[] {
         // Medium is already this book's own cast, so hard cannot sit tighter;
         // what it adds is the extra two options. A four-figure book cannot fill
         // six slots from its own list, and the chain widens to the division
-        // rather than let the hardest setting render the shortest card (#38).
+        // rather than let the hardest setting render the shortest card (#40).
         ...scopedSets(f.name, `figw-${key}`, {
           medium: d.figures.map((x) => x.name),
           easy: [() => allFigureNames],
@@ -425,7 +425,7 @@ function frameItems(d: BookDetail): Item[] {
       // Only the prophets ask this (#9), and the prophets are exactly where a
       // canon-wide pool gives the game away: "why was Joel written?" against
       // Philemon and Leviticus answers itself. Hard keeps it among the other
-      // Minor Prophets, whose stated purposes genuinely overlap (#38).
+      // Minor Prophets, whose stated purposes genuinely overlap (#40).
       ...scopedSets(d.purpose, `pur-${d.book}`, {
         medium: allPurposes,
         easy: [() => allPurposes],
@@ -454,7 +454,7 @@ function frameItems(d: BookDetail): Item[] {
     // Dates are the clearest case for scoping: books in one division were
     // written within decades of each other, so the division's dates are the
     // options a reader actually has to weigh. The canon's span a millennium,
-    // which quietly turns this into an OT-or-NT question (#38).
+    // which quietly turns this into an OT-or-NT question (#40).
     ...scopedSets(d.written, `wr-${d.book}`, {
       medium: allWritten,
       easy: [() => allWritten],
@@ -500,7 +500,7 @@ function frameItems(d: BookDetail): Item[] {
       // `writtenFrom` is recorded almost only for the Pauline epistles, so the
       // division ring and the canon-wide pool are nearly the same handful of
       // cities. The scoping is honest but thin here; the widening and the
-      // thinness guard are what keep the card full (#38).
+      // thinness guard are what keep the card full (#40).
       ...scopedSets(d.writtenFrom, `frm-${d.book}`, {
         medium: froms,
         easy: [() => froms],
@@ -551,7 +551,7 @@ function crossBookItems(): Item[] {
       // This item is deliberately cross-book, so medium spans the canon. Hard
       // narrows to the cast of the book the episode came from: the golden calf
       // against Aaron, Joshua and Hur is a question about Exodus; against
-      // Nehemiah and Titus it is a question about the table of contents (#38).
+      // Nehemiah and Titus it is a question about the table of contents (#40).
       ...scopedSets(answer, `xw-${d.book}-${e.name}`, {
         medium: others,
         easy: [() => others],

--- a/src/lib/generate-essentials.ts
+++ b/src/lib/generate-essentials.ts
@@ -51,7 +51,7 @@ function slug(s: string): string {
  * other entries of its own list — and nothing else. That is a perfectly good
  * medium set, but with no `distractorsBy` on the item the render site has
  * nothing to swap in, so the easy/medium/hard control was inert across the
- * whole must-know section: three settings, one question (#38).
+ * whole must-know section: three settings, one question (#40).
  *
  * The medium set is not what changes here. `scopedSets` is handed the same
  * pool and the same seed the call site used before, so `Item.distractors` is
@@ -111,7 +111,7 @@ function family(list: EssentialList): EssentialList[] {
  * Each ring contains the one before it. `layeredPool` takes a ring whole, so a
  * ring that dropped its own list's entries on the way out would hand a widened
  * hard card *easier* options than the medium card it replaces — the exact
- * inversion the layered shape exists to prevent (#38).
+ * inversion the layered shape exists to prevent (#40).
  *
  * The widening is gated on the reason it exists. Its whole job is to stop hard
  * rendering *fewer or easier* choices than medium, so a list that already beats
@@ -120,7 +120,7 @@ function family(list: EssentialList): EssentialList[] {
  * shows and all four are dates. Widened, that card read
  * "~1500 BC / 46 / Ehud / 7 / Jephthah / Elisha" — the answer was the only date
  * on screen, a giveaway, and hard came out easier than medium. Tight and one
- * short beats padded and shape-mismatched (#38).
+ * short beats padded and shape-mismatched (#40).
  *
  * The rings below are therefore live code for a list too short to beat medium
  * on its own — four entries or fewer, which none currently is — and every list
@@ -205,7 +205,7 @@ function isRenaming(a: string, b: string): boolean {
  * sibling's phrasing of the same periods, and falls back to the list's own
  * groups when the renaming guard thins that below three. Easy is genuinely
  * easier here mostly because it renders two wrong options where hard renders
- * five — an honest limit of the data rather than of the scoping (#38).
+ * five — an honest limit of the data rather than of the scoping (#40).
  */
 function groupHardChain(list: EssentialList, answer: string): (() => string[])[] {
   const own = groupPool(list);

--- a/src/lib/generate-essentials.ts
+++ b/src/lib/generate-essentials.ts
@@ -1,7 +1,8 @@
 import { BOOKS } from '../data/books';
 import { ESSENTIALS, type EssentialEntry, type EssentialList } from '../data/essentials';
 import type { Item } from '../data/types';
-import { pickDistractors } from './rng';
+import { scopedSets } from './distractors';
+import { DIFFICULTY_SPEC } from './difficulty';
 
 /** Chapters `books.ts` already names as key chapters, per book. */
 const KEY_CHAPTERS = new Map<string, Set<number>>(
@@ -43,6 +44,191 @@ function slug(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
 }
 
+/* -------------------------------------------------------------- difficulty */
+
+/**
+ * Every card in this file used to bake exactly one set of wrong options — the
+ * other entries of its own list — and nothing else. That is a perfectly good
+ * medium set, but with no `distractorsBy` on the item the render site has
+ * nothing to swap in, so the easy/medium/hard control was inert across the
+ * whole must-know section: three settings, one question (#38).
+ *
+ * The medium set is not what changes here. `scopedSets` is handed the same
+ * pool and the same seed the call site used before, so `Item.distractors` is
+ * byte-for-byte what it has always been — item ids key SRS history, and
+ * validate.ts, the content-contract test and every rendered card read that
+ * field. All that is new is the two alternates alongside it.
+ *
+ * The scoping principle for a pair list is that the list *is* the confusable
+ * set. "Which chapter is the Fall?" is a real question when the options are
+ * the other eleven Genesis landmarks and a giveaway when one of them is Ehud:
+ *
+ *   hard    the entries of this same list, widened only when the list is too
+ *           short to out-offer medium on its own (see `hardChain`);
+ *   easy    entries from a list on the far side of the Testament seam, minus
+ *           anything this list itself indexes — wrong on sight;
+ *   medium  untouched.
+ */
+
+/** Wrong options a medium card renders — the bar a hard card has to clear. */
+const MEDIUM_WRONG_OPTIONS = DIFFICULTY_SPEC.medium.wrongOptions;
+
+/** Which half of the pair a question's options are drawn from. */
+type Side = 'cue' | 'what';
+
+function sideValues(list: EssentialList, side: Side): string[] {
+  return list.entries.map((e) => (side === 'cue' ? e.cue : e.what));
+}
+
+function flatten(lists: EssentialList[], side: Side): string[] {
+  return lists.flatMap((l) => sideValues(l, side));
+}
+
+/**
+ * Lists near enough that their entries are still a fair *hard* option: another
+ * index of the same book (Genesis by chapter and the seven days of creation),
+ * or another list of the same kind on the same side of the seam (the key
+ * epistle chapters and the parables of Luke are both NT chapter indexes).
+ *
+ * Family never crosses the Testament seam — same book implies same testament,
+ * and the topic arm requires it — which is what keeps it disjoint from the easy
+ * pool below. No string can be reached by both a tight ring and the "obviously
+ * wrong" one.
+ */
+function family(list: EssentialList): EssentialList[] {
+  return ESSENTIALS.filter(
+    (l) =>
+      l.id !== list.id &&
+      ((!!l.book && l.book === list.book) ||
+        (l.testament === list.testament && l.topic === list.topic)),
+  );
+}
+
+/**
+ * Tightest first: this list, then this list plus its family, then everything on
+ * this side of the seam, then the whole must-know set.
+ *
+ * Each ring contains the one before it. `layeredPool` takes a ring whole, so a
+ * ring that dropped its own list's entries on the way out would hand a widened
+ * hard card *easier* options than the medium card it replaces — the exact
+ * inversion the layered shape exists to prevent (#38).
+ *
+ * The widening is gated on the reason it exists. Its whole job is to stop hard
+ * rendering *fewer or easier* choices than medium, so a list that already beats
+ * medium's three wrong options from its own entries does not widen at all: the
+ * five round numbers have four rivals each, which is one more than medium
+ * shows and all four are dates. Widened, that card read
+ * "~1500 BC / 46 / Ehud / 7 / Jephthah / Elisha" — the answer was the only date
+ * on screen, a giveaway, and hard came out easier than medium. Tight and one
+ * short beats padded and shape-mismatched (#38).
+ *
+ * The rings below are therefore live code for a list too short to beat medium
+ * on its own — four entries or fewer, which none currently is — and every list
+ * of six or more satisfies the first ring outright. Only a genuinely tiny list
+ * would ever reach the testament or canon-wide rings.
+ */
+function hardChain(list: EssentialList, side: Side): (() => string[])[] {
+  const own = sideValues(list, side);
+  const sameTestament = ESSENTIALS.filter((l) => l.id !== list.id && l.testament === list.testament);
+  // Entries are unique within a list — validate.ts gates both sides — so every
+  // other entry is one usable rival.
+  if (own.length - 1 > MEDIUM_WRONG_OPTIONS) return [() => own];
+  return [
+    () => own,
+    () => [...own, ...flatten(family(list), side)],
+    () => [...own, ...flatten(sameTestament, side)],
+    () => flatten(ESSENTIALS, side),
+  ];
+}
+
+/**
+ * Widest first, because the whole job of an easy option is to be wrong on
+ * sight. The other Testament is the cheapest guarantee of that and — see
+ * `family` — is the one region no hard ring short of the last can reach.
+ *
+ * The subtraction matters more than the source. Half these lists are indexed by
+ * bare chapter numbers, so John's "11" and Genesis's "11" are the same string;
+ * borrowing it back as an easy option would quietly rebuild the medium set. Any
+ * value this list already indexes is therefore dropped, whichever list it came
+ * from.
+ *
+ * The last ring is this list's own pool. It fires only if a list is ever left
+ * with nothing outside it to borrow, and it is here because an *empty* easy set
+ * would render a question with a single option — worse than an easy set that is
+ * merely no easier than medium.
+ */
+function easyChain(list: EssentialList, side: Side): (() => string[])[] {
+  const own = new Set(sideValues(list, side));
+  const kin = new Set(family(list).map((l) => l.id));
+  const outside = (lists: EssentialList[]) => flatten(lists, side).filter((v) => !own.has(v));
+  return [
+    () => outside(ESSENTIALS.filter((l) => l.testament !== list.testament)),
+    () => outside(ESSENTIALS.filter((l) => l.id !== list.id && !kin.has(l.id))),
+    () => [...own],
+  ];
+}
+
+/** The group pool `groupItems` offers — the list's groups, decoy last. */
+function groupPool(list: EssentialList): string[] {
+  const groups = [...new Set(list.entries.map((e) => e.group).filter((g): g is string => !!g))];
+  return list.groupDecoy ? [...groups, list.groupDecoy] : groups;
+}
+
+/**
+ * "The northern kingdom" against "The northern kingdom of Israel" is not a
+ * wrong option, it is the right one said shorter.
+ *
+ * The two grouped lists name the same periods with different fullness, and a
+ * group pool has to widen across them to reach six choices at all, so without
+ * this guard hard mode would mark a correct answer wrong. Matching on a token
+ * prefix rather than a substring is deliberate: the pair lists are indexed by
+ * bare numbers, where "1" sits inside "11", "12" and "119", and a substring
+ * rule would gut them if it were ever reused there.
+ */
+function isRenaming(a: string, b: string): boolean {
+  const tokens = (s: string) =>
+    s.toLowerCase().replace(/^the\s+/, '').split(/[^a-z0-9]+/).filter(Boolean);
+  const x = tokens(a);
+  const y = tokens(b);
+  const [short, long] = x.length <= y.length ? [x, y] : [y, x];
+  return short.length > 0 && short.every((w, i) => long[i] === w);
+}
+
+/**
+ * Group cards ask which period or kingdom an entry belongs to, and only two
+ * lists have groups at all — the major kings and the prophets by period. Both
+ * are OT people lists, so they are each other's family and there is no
+ * unrelated list to borrow from.
+ *
+ * That shapes both chains. Hard has to widen into the sibling list to reach six
+ * choices, since a list's own groups number four at most; easy borrows the
+ * sibling's phrasing of the same periods, and falls back to the list's own
+ * groups when the renaming guard thins that below three. Easy is genuinely
+ * easier here mostly because it renders two wrong options where hard renders
+ * five — an honest limit of the data rather than of the scoping (#38).
+ */
+function groupHardChain(list: EssentialList, answer: string): (() => string[])[] {
+  const own = groupPool(list);
+  const borrow = (lists: EssentialList[]) =>
+    lists.flatMap(groupPool).filter((g) => !isRenaming(g, answer));
+  return [
+    () => own,
+    () => [...own, ...borrow(family(list))],
+    () => [...own, ...borrow(ESSENTIALS.filter((l) => l.id !== list.id))],
+  ];
+}
+
+function groupEasyChain(list: EssentialList, answer: string): (() => string[])[] {
+  const own = groupPool(list);
+  return [
+    () =>
+      ESSENTIALS.filter((l) => l.id !== list.id)
+        .flatMap(groupPool)
+        .filter((g) => !own.includes(g) && !isRenaming(g, answer)),
+    () => own,
+  ];
+}
+
 /** The pair itself, then where it comes from — a miss should teach the entry. */
 function why(list: EssentialList, e: EssentialEntry): string {
   return [`${e.cue} — ${e.what}.`, e.group ? `${e.group}.` : null, e.note, list.source]
@@ -54,6 +240,10 @@ function listItems(list: EssentialList): Item[] {
   const items: Item[] = [];
   const cues = list.entries.map((e) => e.cue);
   const whats = list.entries.map((e) => e.what);
+  // The chains are per list, not per entry — `layeredPool` re-walks them for
+  // every card, but which lists they draw from never varies inside one list.
+  const forwardScopes = { easy: easyChain(list, 'what'), hard: hardChain(list, 'what') };
+  const backScopes = { easy: easyChain(list, 'cue'), hard: hardChain(list, 'cue') };
 
   for (const e of list.entries) {
     const key = `${list.id}-${slug(e.cue)}`;
@@ -64,7 +254,9 @@ function listItems(list: EssentialList): Item[] {
         id: `ess-${key}-f`, kind: 'mcq', topic: list.topic, tier: 1, book,
         prompt: fill(list.forward, e),
         answer: e.what,
-        distractors: pickDistractors(whats, e.what, 3, `essf-${key}`),
+        // Same pool, same seed, same count as before — `distractors` comes out
+        // byte-identical; what is new is the easy and hard sets beside it.
+        ...scopedSets(e.what, `essf-${key}`, { medium: whats, ...forwardScopes }),
         explain: why(list, e),
       });
     }
@@ -74,7 +266,7 @@ function listItems(list: EssentialList): Item[] {
         id: `ess-${key}-b`, kind: 'mcq', topic: list.topic, tier: 1, book,
         prompt: fill(list.back, e),
         answer: e.cue,
-        distractors: pickDistractors(cues, e.cue, 3, `essb-${key}`),
+        ...scopedSets(e.cue, `essb-${key}`, { medium: cues, ...backScopes }),
         explain: why(list, e),
       });
     }
@@ -90,8 +282,7 @@ function listItems(list: EssentialList): Item[] {
  */
 function groupItems(list: EssentialList): Item[] {
   if (!list.groupAsk) return [];
-  const groups = [...new Set(list.entries.map((e) => e.group).filter((g): g is string => !!g))];
-  const pool = list.groupDecoy ? [...groups, list.groupDecoy] : groups;
+  const pool = groupPool(list);
   if (pool.length < 4) return [];
 
   return list.entries
@@ -101,7 +292,14 @@ function groupItems(list: EssentialList): Item[] {
       book: e.book ?? list.book,
       prompt: fill(list.groupAsk!, e),
       answer: e.group!,
-      distractors: pickDistractors(pool, e.group!, 3, `essg-${list.id}-${e.cue}`),
+      // The seed is the raw cue, not the slug the other two cards use. It is
+      // wrong-looking and it stays: changing it would reshuffle every group
+      // card's medium options.
+      ...scopedSets(e.group!, `essg-${list.id}-${e.cue}`, {
+        medium: pool,
+        easy: groupEasyChain(list, e.group!),
+        hard: groupHardChain(list, e.group!),
+      }),
       // The group is the answer here, so `why` would just repeat it back.
       explain: [`${e.cue} — ${e.what}.`, e.note, list.source].filter(Boolean).join(' '),
     }));

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -29,7 +29,7 @@ function siblingNames(bookId: string): string[] {
 
 /*
  * ---------------------------------------------------------------------------
- * Scoped option pools (#38)
+ * Scoped option pools (#40)
  * ---------------------------------------------------------------------------
  *
  * Difficulty used to bite on roughly a third of the bank: the questions routed
@@ -137,7 +137,7 @@ function placePools(pl: Place, extract: (x: Place) => string[]): (() => string[]
  * correct one out without the reader knowing a thing about the canon. What
  * makes these hard is proximity in the running order: Ezra against Nehemiah,
  * Esther and Chronicles is a question; Ezra against Matthew is a free point.
- * Hence `neighborBooks`/`distantBooks`, which cross the seam on purpose (#38).
+ * Hence `neighborBooks`/`distantBooks`, which cross the seam on purpose (#40).
  *
  * Two further notes on the medium set:
  *
@@ -209,7 +209,7 @@ function buildBookItems(): Item[] {
         answer: b.name,
         // Medium already draws from the division (`siblingNames`); hard keeps
         // that and widens only when a five-book division cannot fill six
-        // choices, easy goes canon-wide (#38).
+        // choices, easy goes canon-wide (#40).
         ...scopedSets(b.name, `s2b-${b.id}`, {
           medium: siblingNames(b.id),
           easy: [() => bookNames],
@@ -374,7 +374,7 @@ function buildPeopleItems(): Item[] {
   // field from people in the answer's own book, then era, then Testament, so
   // the wrong fathers are other fathers from the same story. Easy keeps the
   // canon-wide list these questions have always used — a father from Acts
-  // against a question about Genesis is wrong on sight (#38).
+  // against a question about Genesis is wrong on sight (#40).
   for (const p of PEOPLE) {
     if (p.father && allFathers.length >= 4) {
       items.push({
@@ -522,7 +522,7 @@ function buildTimelineItems(): Item[] {
       prompt: `Which era of biblical history is this? ${e.summary}`,
       answer: e.name,
       // Eras are one ordered spine, so "near" is `seq` and nothing else: hard
-      // offers the eras either side of this one, easy the ones an age away (#38).
+      // offers the eras either side of this one, easy the ones an age away (#40).
       ...scopedSets(e.name, `era-${e.id}`, {
         medium: eraNames,
         easy: [eraNamesBeyond(e, 4), () => eraNames],
@@ -592,7 +592,7 @@ function buildListItems(): Item[] {
         // question inverts the usual logic: a member of some *other* list is
         // also "not part of ${list.title}", so the canon-wide pool that makes
         // every other card easy would put a second correct answer on this one.
-        // Difficulty here is the number of choices, not their provenance (#38).
+        // Difficulty here is the number of choices, not their provenance (#40).
         ...scopedSets(decoy, `notd-${list.id}-${di}`, {
           medium: list.items,
           easy: [() => list.items],

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -1,12 +1,22 @@
-import { BOOKS, isPropheticBook } from '../data/books';
+import {
+  BOOKS,
+  BOOKS_BY_ID,
+  booksNear,
+  distantBooks,
+  isPropheticBook,
+  neighborBooks,
+  sameTestamentBooks,
+} from '../data/books';
 import { PEOPLE, PLACES } from '../data/people';
+import type { Person, Place } from '../data/people';
 import { ERAS, EVENTS } from '../data/timeline';
+import type { Era } from '../data/timeline';
 import { AUTHORED, LIST_DECOYS, LISTS } from '../data/extras';
-import type { Item } from '../data/types';
-import { distractorSets } from './distractors';
+import type { Book, Item } from '../data/types';
+import { distractorSets, scopedSets } from './distractors';
 import { buildDetailItems } from './generate-detail';
 import { buildEssentialItems } from './generate-essentials';
-import { pickDistractors, seededShuffle } from './rng';
+import { pickDistractors } from './rng';
 
 const bookNames = BOOKS.map((b) => b.name);
 
@@ -15,6 +25,170 @@ function siblingNames(bookId: string): string[] {
   const b = BOOKS.find((x) => x.id === bookId)!;
   const sameDivision = BOOKS.filter((x) => x.division === b.division && x.id !== b.id).map((x) => x.name);
   return sameDivision.length >= 3 ? sameDivision : bookNames.filter((n) => n !== b.name);
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Scoped option pools (#38)
+ * ---------------------------------------------------------------------------
+ *
+ * Difficulty used to bite on roughly a third of the bank: the questions routed
+ * through `distractorSets` carried easy and hard alternates, and everything
+ * else fell back to one canon-wide `pickDistractors` draw at every setting.
+ * That is why "hard" did not feel hard — a question about Leviticus would
+ * happily offer Philemon, which is not a harder question, just a different
+ * subject you can rule out without knowing anything.
+ *
+ * The helpers below give every remaining family the same shape the existing
+ * ones already have: `hard` is a chain of pool builders ordered tightest-first
+ * that `layeredPool` widens through only when the tight pool cannot fill a
+ * six-choice card, and `easy` is the widest pool available, because the point
+ * of easy is wrong options that are wrong on sight.
+ *
+ * `medium` is never touched. It is what lands in `Item.distractors`, which
+ * validate.ts, the content-contract spec and every card rendered at the default
+ * setting read, so each call below passes the *identical* pool expression and
+ * seed the generator used before, and `scopedSets` reproduces the old value
+ * exactly.
+ */
+
+/**
+ * The rings a book-shaped question tightens through: the answer's own division,
+ * one division further out, its Testament, then the whole canon.
+ *
+ * This is the same fence `nearbyPool` uses for the medium pools, for the same
+ * reason (#10, #12) — a wrong option only tests anything if it is a plausible
+ * neighbour. Book-order questions are the documented exception; see
+ * `bookOrderSets`.
+ */
+function bookRings(bookId: string): (() => Book[])[] {
+  return [
+    () => booksNear(bookId, 0),
+    () => booksNear(bookId, 1),
+    () => sameTestamentBooks(bookId),
+    () => BOOKS,
+  ];
+}
+
+/** `bookRings` projected through `extract`, ready to hand to `scopedSets`. */
+function bookPools(bookId: string, extract: (b: Book) => string[]): (() => string[])[] {
+  return bookRings(bookId).map((ring) => () => ring().flatMap(extract));
+}
+
+/**
+ * The rings a People or Relationships question tightens through: the figures of
+ * the answer's own book, then of its era, then of its Testament, then everyone.
+ *
+ * Book first rather than era first because "who is this?" is nearly always
+ * answered from a story, and the people you confuse with Gideon are the other
+ * judges in Judges — not everyone who happens to sit in the same century.
+ */
+function peopleRings(p: Person): (() => Person[])[] {
+  const testament = BOOKS_BY_ID[p.book]?.testament;
+  return [
+    () => PEOPLE.filter((x) => x.book === p.book),
+    () => PEOPLE.filter((x) => x.era === p.era),
+    () => PEOPLE.filter((x) => BOOKS_BY_ID[x.book]?.testament === testament),
+    () => PEOPLE,
+  ];
+}
+
+/**
+ * `peopleRings` projected through `extract`.
+ *
+ * Any per-question exclusion belongs inside `extract`, not after the pool is
+ * built — the same lesson #12 recorded for events. A ring that looks full and
+ * only loses its illegal entries afterwards stops the widening early and leaves
+ * the card short.
+ */
+function peoplePools(p: Person, extract: (x: Person) => string[]): (() => string[])[] {
+  return peopleRings(p).map((ring) => () => ring().flatMap(extract));
+}
+
+/**
+ * The rings a Places question tightens through.
+ *
+ * `Place` carries a `book` and an `era` and nothing finer — no region, no
+ * coordinates — so locality here means "belongs to the same stretch of the
+ * story", which is the association a reader actually has. Gethsemane against
+ * Golgotha and the Mount of Olives is a real question; Gethsemane against Ur is
+ * not.
+ */
+function placeRings(pl: Place): (() => Place[])[] {
+  const testament = BOOKS_BY_ID[pl.book]?.testament;
+  return [
+    () => PLACES.filter((x) => x.book === pl.book),
+    () => PLACES.filter((x) => x.era === pl.era),
+    () => PLACES.filter((x) => BOOKS_BY_ID[x.book]?.testament === testament),
+    () => PLACES,
+  ];
+}
+
+function placePools(pl: Place, extract: (x: Place) => string[]): (() => string[])[] {
+  return placeRings(pl).map((ring) => () => ring().flatMap(extract));
+}
+
+/**
+ * Book-order questions are the one family where the Testament seam is the wrong
+ * fence, and canonical distance is the right one.
+ *
+ * "Which book immediately follows Malachi?" has a New Testament answer to an
+ * Old Testament question, so scoping the options by Testament would mark the
+ * correct one out without the reader knowing a thing about the canon. What
+ * makes these hard is proximity in the running order: Ezra against Nehemiah,
+ * Esther and Chronicles is a question; Ezra against Matthew is a free point.
+ * Hence `neighborBooks`/`distantBooks`, which cross the seam on purpose (#38).
+ *
+ * Two further notes on the medium set:
+ *
+ *  - The subject book was showing up as a wrong option on its own question —
+ *    "Which book immediately precedes Leviticus?" offered Leviticus, because
+ *    `pickDistractors` only excludes the *answer*. It has to come out of every
+ *    pool, medium included.
+ *  - It cannot come out of the medium *pool*, though. `seededShuffle` is a
+ *    function of the array handed to it, so dropping one of 66 names reshuffles
+ *    all 130 book-order cards — including the four-option Genesis card the
+ *    content contract pins. So medium draws one extra and drops the subject
+ *    after the fact: the 124 cards that never had the bug keep their exact
+ *    options, and only the six that did are corrected.
+ */
+function bookOrderSets(subject: Book, answer: string, seed: string): Pick<Item, 'distractors' | 'distractorsBy'> {
+  const notSubject = (n: string) => n !== subject.name;
+  const names = (books: Book[]) => books.map((b) => b.name).filter(notSubject);
+  const wholeCanon = bookNames.filter(notSubject);
+
+  const distractors = pickDistractors(bookNames, answer, 4, seed).filter(notSubject).slice(0, 3);
+
+  // `scopedSets` recomputes the medium draw from the pool it is given, which is
+  // the un-post-filtered version; only its alternates are wanted here, so the
+  // corrected `distractors` above is the one that ships.
+  const { distractorsBy } = scopedSets(answer, seed, {
+    medium: wholeCanon,
+    easy: [() => names(distantBooks(subject.id, 12)), () => wholeCanon],
+    hard: [
+      () => names(neighborBooks(subject.id, 4)),
+      () => names(neighborBooks(subject.id, 8)),
+      () => names(sameTestamentBooks(subject.id)),
+      () => wholeCanon,
+    ],
+  });
+
+  return { distractors, distractorsBy };
+}
+
+/**
+ * The rings a Timeline question tightens through, by `seq`.
+ *
+ * Eras are a single ordered spine, so "near" means adjacent in that spine and
+ * nothing else: the Divided Kingdom against the United Kingdom and the Exile is
+ * a real question, against Creation it is not.
+ */
+function eraPools(e: Era, within: number): () => string[] {
+  return () => ERAS.filter((x) => x.id !== e.id && Math.abs(x.seq - e.seq) <= within).map((x) => x.name);
+}
+
+function eraNamesBeyond(e: Era, span: number): () => string[] {
+  return () => ERAS.filter((x) => Math.abs(x.seq - e.seq) > span).map((x) => x.name);
 }
 
 function buildBookItems(): Item[] {
@@ -33,7 +207,14 @@ function buildBookItems(): Item[] {
         id: `gen-summary-to-book-${b.id}`, kind: 'mcq', topic: 'summaries', tier: 1, book: b.id,
         prompt: `Which book is this? "${b.oneLine}"`,
         answer: b.name,
-        distractors: pickDistractors(siblingNames(b.id), b.name, 3, `s2b-${b.id}`),
+        // Medium already draws from the division (`siblingNames`); hard keeps
+        // that and widens only when a five-book division cannot fill six
+        // choices, easy goes canon-wide (#38).
+        ...scopedSets(b.name, `s2b-${b.id}`, {
+          medium: siblingNames(b.id),
+          easy: [() => bookNames],
+          hard: bookPools(b.id, (x) => [x.name]),
+        }),
         explain: b.hook,
       });
 
@@ -41,19 +222,30 @@ function buildBookItems(): Item[] {
         id: `gen-theme-${b.id}`, kind: 'mcq', topic: 'summaries', tier: 2, book: b.id,
         prompt: `What is the central theme of ${b.name}?`,
         answer: b.theme,
-        distractors: pickDistractors(BOOKS.map((x) => x.theme), b.theme, 3, `theme-${b.id}`),
+        // Themes of neighbouring prophets overlap heavily, which is exactly
+        // what makes them a hard set and a canon-wide draw an easy one.
+        ...scopedSets(b.theme, `theme-${b.id}`, {
+          medium: BOOKS.map((x) => x.theme),
+          easy: [() => BOOKS.map((x) => x.theme)],
+          hard: bookPools(b.id, (x) => [x.theme]),
+        }),
         explain: b.oneLine,
       });
     }
 
     // --- Position in canon
+    const nextAnswer = b.order < 66 ? BOOKS[b.order].name : 'Nothing — it is the last book of the Bible';
+    const nextSets = bookOrderSets(b, nextAnswer, `next-${b.id}`);
     items.push({
       id: `gen-position-${b.id}`, kind: 'mcq', topic: 'book-order', tier: 3, book: b.id,
       prompt: `Which book immediately follows ${b.name}?`,
-      answer: b.order < 66 ? BOOKS[b.order].name : 'Nothing — it is the last book of the Bible',
-      distractors: b.order < 66
-        ? pickDistractors(bookNames, BOOKS[b.order].name, 3, `next-${b.id}`)
-        : ['Jude', '3 John', '2 Peter'],
+      answer: nextAnswer,
+      // Revelation's medium options are authored, not drawn — the answer there
+      // is a sentence rather than a book, and the three near-misses at the end
+      // of the canon are the whole question. Only the alternates are generated.
+      ...(b.order < 66
+        ? nextSets
+        : { distractors: ['Jude', '3 John', '2 Peter'], distractorsBy: nextSets.distractorsBy }),
     });
 
     if (b.order > 1) {
@@ -61,7 +253,7 @@ function buildBookItems(): Item[] {
         id: `gen-prev-${b.id}`, kind: 'mcq', topic: 'book-order', tier: 3, book: b.id,
         prompt: `Which book immediately precedes ${b.name}?`,
         answer: BOOKS[b.order - 2].name,
-        distractors: pickDistractors(bookNames, BOOKS[b.order - 2].name, 3, `prev-${b.id}`),
+        ...bookOrderSets(b, BOOKS[b.order - 2].name, `prev-${b.id}`),
       });
     }
 
@@ -138,21 +330,35 @@ function buildPeopleItems(): Item[] {
       id: `gen-who-${p.id}`, kind: 'mcq', topic: 'people', tier: 1, book: p.book,
       prompt: `Who is this? ${p.clue}.`,
       answer: p.name,
-      distractors: pickDistractors(names, p.name, 3, `who-${p.id}`),
+      ...scopedSets(p.name, `who-${p.id}`, {
+        medium: names,
+        easy: [() => names],
+        hard: peoplePools(p, (x) => [x.name]),
+      }),
       explain: `${p.name}: ${p.role}.`,
     });
     items.push({
       id: `gen-role-${p.id}`, kind: 'mcq', topic: 'people', tier: 2, book: p.book,
       prompt: `Who was ${p.name}?`,
       answer: p.role,
-      distractors: pickDistractors(roles, p.role, 3, `role-${p.id}`),
+      ...scopedSets(p.role, `role-${p.id}`, {
+        medium: roles,
+        easy: [() => roles],
+        hard: peoplePools(p, (x) => [x.role]),
+      }),
       explain: p.clue,
     });
     items.push({
       id: `gen-personbook-${p.id}`, kind: 'mcq', topic: 'people', tier: 3, book: p.book,
       prompt: `In which book do we primarily read about ${p.name}?`,
       answer: BOOKS.find((b) => b.id === p.book)!.name,
-      distractors: pickDistractors(bookNames, BOOKS.find((b) => b.id === p.book)!.name, 3, `pb-${p.id}`),
+      // The answer here is a book, so this scopes like a book question rather
+      // than a people one: same division first, then the Testament.
+      ...scopedSets(BOOKS.find((b) => b.id === p.book)!.name, `pb-${p.id}`, {
+        medium: bookNames,
+        easy: [() => bookNames],
+        hard: bookPools(p.book, (x) => [x.name]),
+      }),
     });
   }
 
@@ -164,13 +370,22 @@ function buildPeopleItems(): Item[] {
   const allTribes = [...new Set(PEOPLE.map((p) => p.tribe).filter((x): x is string => !!x))];
   const allDeaths = [...new Set(PEOPLE.map((p) => p.died).filter((x): x is string => !!x))];
 
+  // Every relationship question scopes the same way: hard draws the *same*
+  // field from people in the answer's own book, then era, then Testament, so
+  // the wrong fathers are other fathers from the same story. Easy keeps the
+  // canon-wide list these questions have always used — a father from Acts
+  // against a question about Genesis is wrong on sight (#38).
   for (const p of PEOPLE) {
     if (p.father && allFathers.length >= 4) {
       items.push({
         id: `gen-father-${p.id}`, kind: 'mcq', topic: 'relationships', tier: 2, book: p.book,
         prompt: `Who was the father of ${p.name}?`,
         answer: p.father,
-        distractors: pickDistractors(allFathers, p.father, 3, `fa-${p.id}`),
+        ...scopedSets(p.father, `fa-${p.id}`, {
+          medium: allFathers,
+          easy: [() => allFathers],
+          hard: peoplePools(p, (x) => (x.father ? [x.father] : [])),
+        }),
         explain: `${p.name}: ${p.role}.`,
       });
     }
@@ -179,7 +394,11 @@ function buildPeopleItems(): Item[] {
         id: `gen-mother-${p.id}`, kind: 'mcq', topic: 'relationships', tier: 3, book: p.book,
         prompt: `Who was the mother of ${p.name}?`,
         answer: p.mother,
-        distractors: pickDistractors(allMothers, p.mother, 3, `mo-${p.id}`),
+        ...scopedSets(p.mother, `mo-${p.id}`, {
+          medium: allMothers,
+          easy: [() => allMothers],
+          hard: peoplePools(p, (x) => (x.mother ? [x.mother] : [])),
+        }),
         explain: `${p.name}: ${p.role}.`,
       });
     }
@@ -188,7 +407,11 @@ function buildPeopleItems(): Item[] {
         id: `gen-spouse-${p.id}`, kind: 'mcq', topic: 'relationships', tier: 2, book: p.book,
         prompt: `Who was married to ${p.name}?`,
         answer: p.spouse,
-        distractors: pickDistractors(allSpouses, p.spouse, 3, `sp-${p.id}`),
+        ...scopedSets(p.spouse, `sp-${p.id}`, {
+          medium: allSpouses,
+          easy: [() => allSpouses],
+          hard: peoplePools(p, (x) => (x.spouse ? [x.spouse] : [])),
+        }),
         explain: p.clue,
       });
     }
@@ -201,7 +424,17 @@ function buildPeopleItems(): Item[] {
           id: `gen-child-${p.id}`, kind: 'mcq', topic: 'relationships', tier: 3, book: p.book,
           prompt: `Which of these was a child of ${p.name}?`,
           answer: child,
-          distractors: pickDistractors(otherChildren, child, 3, `ch-${p.id}`),
+          // The "not one of p's own children" ban lives inside the extract, not
+          // after the pool is built, so a tight ring that is full of siblings
+          // widens instead of quietly shipping a card with a second right
+          // answer on it (#12).
+          ...scopedSets(child, `ch-${p.id}`, {
+            medium: otherChildren,
+            easy: [() => otherChildren],
+            hard: peoplePools(p, (x) =>
+              x.id === p.id ? [] : (x.children ?? []).filter((c) => !p.children!.includes(c)),
+            ),
+          }),
           explain: `${p.name}’s children: ${p.children.join(', ')}.`,
         });
       }
@@ -211,7 +444,11 @@ function buildPeopleItems(): Item[] {
         id: `gen-tribe-${p.id}`, kind: 'mcq', topic: 'relationships', tier: 3, book: p.book,
         prompt: `Which tribe did ${p.name} belong to?`,
         answer: p.tribe,
-        distractors: pickDistractors(allTribes, p.tribe, 3, `tr-${p.id}`),
+        ...scopedSets(p.tribe, `tr-${p.id}`, {
+          medium: allTribes,
+          easy: [() => allTribes],
+          hard: peoplePools(p, (x) => (x.tribe ? [x.tribe] : [])),
+        }),
         explain: p.role,
       });
     }
@@ -220,7 +457,11 @@ function buildPeopleItems(): Item[] {
         id: `gen-died-${p.id}`, kind: 'mcq', topic: 'people', tier: 3, book: p.book,
         prompt: `How did ${p.name} die?`,
         answer: p.died,
-        distractors: pickDistractors(allDeaths, p.died, 3, `di-${p.id}`),
+        ...scopedSets(p.died, `di-${p.id}`, {
+          medium: allDeaths,
+          easy: [() => allDeaths],
+          hard: peoplePools(p, (x) => (x.died ? [x.died] : [])),
+        }),
         explain: p.clue,
       });
     }
@@ -232,7 +473,13 @@ function buildPeopleItems(): Item[] {
           id: `gen-aka-${p.id}`, kind: 'mcq', topic: 'people', tier: 3, book: p.book,
           prompt: `By what other name is ${p.name} known?`,
           answer: aka,
-          distractors: pickDistractors(others, aka, 3, `aka-${p.id}`),
+          // p's own aliases are excluded inside the extract for the same reason
+          // as the children ban above: every one of them is a right answer.
+          ...scopedSets(aka, `aka-${p.id}`, {
+            medium: others,
+            easy: [() => others],
+            hard: peoplePools(p, (x) => (x.id === p.id ? [] : x.alsoKnownAs ?? [])),
+          }),
           explain: p.clue,
         });
       }
@@ -244,13 +491,21 @@ function buildPeopleItems(): Item[] {
       id: `gen-place-${pl.id}`, kind: 'mcq', topic: 'places', tier: 2,
       prompt: `Which place is this? ${pl.what}.`,
       answer: pl.name,
-      distractors: pickDistractors(PLACES.map((x) => x.name), pl.name, 3, `pl-${pl.id}`),
+      ...scopedSets(pl.name, `pl-${pl.id}`, {
+        medium: PLACES.map((x) => x.name),
+        easy: [() => PLACES.map((x) => x.name)],
+        hard: placePools(pl, (x) => [x.name]),
+      }),
     });
     items.push({
       id: `gen-placewhat-${pl.id}`, kind: 'mcq', topic: 'places', tier: 3,
       prompt: `What is ${pl.name} known for?`,
       answer: pl.what,
-      distractors: pickDistractors(PLACES.map((x) => x.what), pl.what, 3, `plw-${pl.id}`),
+      ...scopedSets(pl.what, `plw-${pl.id}`, {
+        medium: PLACES.map((x) => x.what),
+        easy: [() => PLACES.map((x) => x.what)],
+        hard: placePools(pl, (x) => [x.what]),
+      }),
     });
   }
 
@@ -266,14 +521,24 @@ function buildTimelineItems(): Item[] {
       id: `gen-era-${e.id}`, kind: 'mcq', topic: 'timeline', tier: 2,
       prompt: `Which era of biblical history is this? ${e.summary}`,
       answer: e.name,
-      distractors: pickDistractors(eraNames, e.name, 3, `era-${e.id}`),
+      // Eras are one ordered spine, so "near" is `seq` and nothing else: hard
+      // offers the eras either side of this one, easy the ones an age away (#38).
+      ...scopedSets(e.name, `era-${e.id}`, {
+        medium: eraNames,
+        easy: [eraNamesBeyond(e, 4), () => eraNames],
+        hard: [eraPools(e, 2), eraPools(e, 4), () => eraNames],
+      }),
       explain: `${e.name}: ${e.span}.`,
     });
     items.push({
       id: `gen-erabooks-${e.id}`, kind: 'mcq', topic: 'timeline', tier: 3,
       prompt: `During which era does ${e.markers[0]} occur?`,
       answer: e.name,
-      distractors: pickDistractors(eraNames, e.name, 3, `erab-${e.id}`),
+      ...scopedSets(e.name, `erab-${e.id}`, {
+        medium: eraNames,
+        easy: [eraNamesBeyond(e, 4), () => eraNames],
+        hard: [eraPools(e, 2), eraPools(e, 4), () => eraNames],
+      }),
       explain: e.summary,
     });
   }
@@ -308,6 +573,12 @@ function buildTimelineItems(): Item[] {
 function buildListItems(): Item[] {
   const items: Item[] = [];
 
+  // Members of every *other* standing list — the "wrong on sight" pool that
+  // makes a positional question easy. It is deliberately not used for the
+  // NOT-in-this-list cards below; see the note there.
+  const otherListItems = (id: string) =>
+    LISTS.filter((l) => l.id !== id).flatMap((l) => l.items);
+
   for (const list of LISTS) {
     // Membership: which of these does NOT belong? One authored decoy against
     // three real members.
@@ -317,7 +588,16 @@ function buildListItems(): Item[] {
         id: `gen-list-not-${list.id}-${di}`, kind: 'mcq', topic: 'summaries', tier: 2,
         prompt: `Which of these is NOT part of ${list.title}?`,
         answer: decoy,
-        distractors: seededShuffle(list.items, `notd-${list.id}-${di}`).slice(0, 3),
+        // All three settings draw from this list and only this list. A NOT
+        // question inverts the usual logic: a member of some *other* list is
+        // also "not part of ${list.title}", so the canon-wide pool that makes
+        // every other card easy would put a second correct answer on this one.
+        // Difficulty here is the number of choices, not their provenance (#38).
+        ...scopedSets(decoy, `notd-${list.id}-${di}`, {
+          medium: list.items,
+          easy: [() => list.items],
+          hard: [() => list.items],
+        }),
         explain: `${list.title} — ${list.note}: ${list.items.join(', ')}.`,
       });
     });
@@ -337,7 +617,15 @@ function buildListItems(): Item[] {
           id: `gen-list-pos-${list.id}-${idx}`, kind: 'mcq', topic: 'summaries', tier: 3,
           prompt: `In ${list.title}, what is #${idx + 1}?`,
           answer: entry,
-          distractors: pickDistractors(list.items, entry, 3, `pos-${list.id}-${idx}`),
+          // Medium is already the tightest honest pool — the other members of
+          // this same list — so hard keeps it and only widens if a short list
+          // cannot fill six choices. Easy is where the setting earns its keep:
+          // an item from a different list is wrong without knowing the order.
+          ...scopedSets(entry, `pos-${list.id}-${idx}`, {
+            medium: list.items,
+            easy: [() => otherListItems(list.id)],
+            hard: [() => list.items, () => [...list.items, ...otherListItems(list.id)]],
+          }),
           explain: list.note,
         });
       });

--- a/src/lib/plan-scope.ts
+++ b/src/lib/plan-scope.ts
@@ -1,0 +1,68 @@
+/**
+ * Turning a study phase into a set of item ids (#38).
+ *
+ * The plan has been decorative since it was written: `buildSchedule` sliced the
+ * calendar, Plan drew it, Dashboard named the current phase — and the daily
+ * review then handed you the whole 6,000-item bank regardless. "Follow the study
+ * plan" is the user's ask, and this is the join it needs: a phase declares
+ * `topics` and a `scope`, an item carries a `topic` and sometimes a `book`, and
+ * the intersection is what the phase actually means by "study this".
+ *
+ * Kept out of data/plan.ts on purpose. That file is pure schedule arithmetic
+ * with no knowledge of the item bank; this one needs `Item`, and pointing the
+ * data layer at the generated bank would make the plan un-testable without it.
+ */
+import type { Phase } from '../data/plan';
+import type { Item } from '../data/types';
+
+/**
+ * Item ids belonging to a phase: the topic must match, and — unless the phase
+ * covers the whole canon — the item must sit in one of its books.
+ *
+ * The ~310 book-less items (the timeline, the standing lists, the whole-canon
+ * counts) are the judgment call here. They are included whenever the topic
+ * matches and `scope` is `'all'`, and excluded outright when the phase names a
+ * book list. That asymmetry is deliberate rather than an oversight: a phase
+ * that says "Old Testament books" is asking you to walk those books, and "how
+ * many books are in the Bible?" is not a fact about any of them — letting it in
+ * would quietly re-widen a scope the plan just narrowed. The phases that do
+ * want that material (Phase 1's summaries, Phase 4's timeline and counts,
+ * Phase 5's mixed review) all carry `scope: 'all'`, so nothing in the plan as
+ * written ends up unreachable.
+ */
+export function planScopeIds(phase: Phase, items: readonly Item[]): Set<string> {
+  const topics = new Set<string>(phase.topics);
+  const books = phase.scope === 'all' ? null : new Set(phase.scope);
+  const out = new Set<string>();
+  for (const item of items) {
+    if (!topics.has(item.topic)) continue;
+    if (books && (!item.book || !books.has(item.book))) continue;
+    out.add(item.id);
+  }
+  return out;
+}
+
+/**
+ * Widen a plan-scoped list with out-of-scope ids, but only when it is too thin
+ * to fill a session.
+ *
+ * This is the edge that decides whether the feature is usable. Late in a phase
+ * the material inside it is all seen and none of it is due yet, and a daily
+ * review that answers "nothing to study" because of a calendar is worse than
+ * one that quietly reaches past it — the reader came to study, and the plan is
+ * meant to prioritise their attention, not ration it.
+ *
+ * Order is `all`'s, so the widening inherits whatever ordering the caller
+ * already trusted; ids already in `scoped` are never repeated.
+ */
+export function withTopUp(scoped: string[], all: string[], want: number): string[] {
+  if (scoped.length >= want) return scoped;
+  const have = new Set(scoped);
+  const out = [...scoped];
+  for (const id of all) {
+    if (out.length >= want) break;
+    if (have.has(id)) continue;
+    out.push(id);
+  }
+  return out;
+}

--- a/src/lib/plan-scope.ts
+++ b/src/lib/plan-scope.ts
@@ -1,5 +1,5 @@
 /**
- * Turning a study phase into a set of item ids (#38).
+ * Turning a study phase into a set of item ids (#40).
  *
  * The plan has been decorative since it was written: `buildSchedule` sliced the
  * calendar, Plan drew it, Dashboard named the current phase — and the daily

--- a/src/lib/srs.ts
+++ b/src/lib/srs.ts
@@ -4,7 +4,8 @@
  * 60 days out is useless when the test is in 40.
  */
 import type { Difficulty } from '../data/types';
-import { shuffle } from './rng';
+import { specFor, type DifficultySpec } from './difficulty';
+import { seededShuffle, shuffle } from './rng';
 
 export type Grade = 0 | 1 | 2 | 3; // again | hard | ok | easy
 
@@ -90,40 +91,69 @@ export function strength(c: CardState | undefined): number {
   return Math.min(1, score * 0.75 + durability * 0.25);
 }
 
+/** What the queue needs to know about an item to order new cards intelligently. */
+export interface ItemMeta {
+  tier: 1 | 2 | 3;
+  book?: string;
+}
+
 export interface QueueOptions {
   /** Max new cards to introduce this session. */
   newLimit: number;
   /** Max total cards this session. */
   sessionLimit: number;
   /**
-   * Which cards a truncated session should favour (#36). Absent means
-   * `medium`, which is no weighting at all.
+   * Which cards the session takes, and in what order it opens new ground
+   * (#36, #38). It now drives three things, not one: how hard the cut at the
+   * session limit leans on per-card ease, how many new cards the limit really
+   * allows, and — the point of #38 — the order unseen material is drawn in.
+   *
+   * Absent means today's behaviour exactly: no ease lean, no reordering, the
+   * configured new-card limit taken at face value. That is deliberately *not*
+   * the same as passing `medium`, which opts into the spec's ordering rules
+   * even where they happen to be no-ops.
    */
   difficulty?: Difficulty;
+  /**
+   * Per-item metadata, keyed by item id. Absent means today's behaviour: book
+   * spreading and tier bias both need to know something about an item that its
+   * id does not carry, so without this they are skipped rather than guessed at.
+   */
+  meta?: Record<string, ItemMeta>;
+  /**
+   * Rotates the shuffled new-card order. Callers pass a per-day value.
+   *
+   * Shuffled has to be unpredictable *between* days and stable *within* one:
+   * a session that reshuffled on every reload would hand you a different set
+   * of new cards mid-study. Seeding on the day gives both. Defaults to the
+   * date derived from `now`.
+   */
+  seed?: string;
 }
-
-/**
- * How far a point of ease can move a card in the queue, expressed in days of
- * borrowed urgency. Large enough to reorder cards of similar overdue-ness,
- * small enough that a badly overdue card still leads — the queue's first duty
- * is that nothing sails past its due date unreviewed.
- */
-const EASE_LEAN_DAYS = 3;
 
 /**
  * Selection priority for a due card: lower goes first, and it is the cut at
  * the session limit that really consumes this.
  *
  * `ease` is the scheduler's own record of how hard *this* user finds *this*
- * card, which makes it the honest signal for the setting: `hard` pulls forward
- * the cards you keep fumbling, `easy` pulls forward the ones you have nearly
- * got. `medium` returns the bare due date — the same number buildQueue has
- * always sorted on, so that path is unchanged rather than merely equivalent.
+ * card, which makes it the honest signal for the setting: a positive lean
+ * (`hard`) pulls forward the cards you keep fumbling, a negative one (`easy`)
+ * pulls forward the ones you have nearly got.
+ *
+ * The magnitude of the lean now comes from the difficulty spec rather than a
+ * constant here (#38), so the setting can say *how much* it leans and not just
+ * which way. It is still measured in days of borrowed urgency, and still kept
+ * small enough that a badly overdue card leads regardless — the queue's first
+ * duty is that nothing sails past its due date unreviewed.
+ *
+ * A lean of 0 (`medium`, and the no-difficulty default) returns the bare due
+ * date early. The arithmetic would come out the same, but returning `c.due`
+ * itself keeps that path byte-identical to the sort buildQueue has always
+ * done, rather than merely equivalent to it.
  */
-function priority(c: CardState, difficulty: Difficulty): number {
-  if (difficulty === 'medium') return c.due;
-  const lean = difficulty === 'hard' ? 1 : -1;
-  return c.due + lean * (c.ease - 2.5) * EASE_LEAN_DAYS * DAY;
+function priority(c: CardState, spec: DifficultySpec): number {
+  if (spec.easeLeanDays === 0) return c.due;
+  return c.due + (c.ease - 2.5) * spec.easeLeanDays * DAY;
 }
 
 /**
@@ -146,24 +176,116 @@ export function buildQueue(
     else if (c.due <= now) due.push(id);
   }
 
-  const difficulty = opts.difficulty ?? 'medium';
-  due.sort((a, b) => priority(cards[a], difficulty) - priority(cards[b], difficulty));
-  const picked = [...due, ...fresh.slice(0, opts.newLimit)];
+  const spec = specFor(opts.difficulty);
+  due.sort((a, b) => priority(cards[a], spec) - priority(cards[b], spec));
+  const picked = [...due, ...orderNew(fresh, opts, spec, now)];
   // Order matters twice here, for different reasons.
   //
   // Selecting: sort by how overdue a card is, interleave the books, and only
   // then cut to the session limit — so a truncated session still takes the
   // most urgent cards and a spread of books, not the first N of one.
   //
-  // The difficulty setting leans on that sort and nothing else (#36): it
-  // changes which cards win the cut, not how they are spread or presented.
-  // New cards are left out of the lean deliberately — every one of them has
-  // the same seeded ease, so there is no signal there to weight on.
+  // The difficulty setting leans on that sort (#36): it changes which due
+  // cards win the cut. Due cards only — every new card carries the same seeded
+  // ease, so there is no signal there to weight on. What decides *which* new
+  // cards get introduced is orderNew (#38), a separate question the ease lean
+  // cannot answer.
   //
   // Presenting: shuffle what survived. The selection above is deterministic,
   // so without this you meet the same cards in the same order every day and
-  // start recalling the sequence rather than the answer (#11).
+  // start recalling the sequence rather than the answer (#11). Note this is
+  // the presentation shuffle, not #38's: it reorders one session's cards after
+  // the cut, and cannot change which cards were introduced in the first place.
   return shuffle(interleave(picked).slice(0, opts.sessionLimit));
+}
+
+/**
+ * Choose which unseen cards this session introduces, and take the difficulty's
+ * share of them (#38).
+ *
+ * The complaint this answers: "build the frame is great in going through all of
+ * the books but it's in order — for hard mode it's too easy to predict." It was
+ * literally true. `fresh` arrives in the bank's generation order, which is the
+ * canonical order, so new material marched Genesis-first through the canon at
+ * every setting. Within-session shuffling never touched that, because it only
+ * reorders cards that have already been chosen.
+ *
+ * So the fix has to happen here, before the cut. Note the ordering of the two
+ * steps: newOrder first, tier bias second and *stable*, so the bias is a bias —
+ * it floats a tier forward while leaving the shuffle intact within that tier.
+ * Sorting by tier first would have the shuffle undo it.
+ *
+ * With no `difficulty` this is the old `fresh.slice(0, newLimit)` untouched,
+ * which is what keeps every existing caller's behaviour exactly as it was.
+ */
+function orderNew(fresh: string[], opts: QueueOptions, spec: DifficultySpec, now: number): string[] {
+  if (!opts.difficulty) return fresh.slice(0, opts.newLimit);
+
+  const meta = opts.meta;
+  let ordered = fresh;
+
+  if (spec.newOrder === 'shuffled') {
+    // Seeded, not Math.random(): the day's new material has to be drawn from
+    // anywhere in the scope, but a reload must not deal a different hand
+    // mid-session. A per-day seed rotates the draw exactly once a day.
+    ordered = seededShuffle(ordered, opts.seed ?? new Date(now).toISOString().slice(0, 10));
+  } else if (spec.newOrder === 'interleaved' && meta) {
+    ordered = spreadByBook(ordered, meta);
+  }
+
+  // Tier bias needs to know each item's tier, and ids do not carry it, so
+  // without meta there is nothing to bias on — skip rather than guess.
+  if (meta && spec.tierBias !== 'balanced') {
+    const dir = spec.tierBias === 'foundation-first' ? 1 : -1;
+    // Array.prototype.sort is stable per spec (ES2019+), which is load-bearing
+    // here: it is what makes this a nudge on top of the order above rather
+    // than a replacement for it.
+    ordered = ordered.slice().sort((a, b) => dir * (tierOf(a, meta) - tierOf(b, meta)));
+  }
+
+  // Easy opens less new ground and spends the session consolidating; hard
+  // pushes more. A configured limit of 0 stays 0 — someone who has switched
+  // new cards off has not asked for one anyway.
+  const limit = opts.newLimit <= 0 ? 0 : Math.max(1, Math.round(opts.newLimit * spec.newLimitFactor));
+  return ordered.slice(0, limit);
+}
+
+function tierOf(id: string, meta: Record<string, ItemMeta>): number {
+  return meta[id]?.tier ?? 2;
+}
+
+function bookOf(id: string, meta: Record<string, ItemMeta>): string {
+  // Same fallback key `interleave` uses, so an item missing a book still gets
+  // grouped the way the rest of the queue groups it.
+  return meta[id]?.book ?? id.split('-').slice(0, 2).join('-');
+}
+
+/**
+ * The beginner-friendly middle: keep the canonical march, but stop it handing
+ * you six consecutive cards from the same book.
+ *
+ * Deliberately *not* a round-robin across books like `interleave` below — that
+ * would deal one card from each of the sixty-six books before returning to
+ * Genesis, which is not a march through the canon at all, it is a random-access
+ * tour with extra steps. Instead this walks the list in order and only defers a
+ * card when it would repeat the book just emitted, which spreads adjacent cards
+ * while leaving the large-scale progression intact.
+ */
+function spreadByBook(ids: string[], meta: Record<string, ItemMeta>): string[] {
+  const remaining = ids.slice();
+  const out: string[] = [];
+  let last: string | undefined;
+  while (remaining.length > 0) {
+    let idx = 0;
+    if (last !== undefined) {
+      const alt = remaining.findIndex((id) => bookOf(id, meta) !== last);
+      if (alt !== -1) idx = alt;
+    }
+    const [id] = remaining.splice(idx, 1);
+    out.push(id);
+    last = bookOf(id, meta);
+  }
+  return out;
 }
 
 /** Spread same-prefix items apart so you are not answering six Genesis cards in a row. */

--- a/src/lib/srs.ts
+++ b/src/lib/srs.ts
@@ -235,7 +235,15 @@ function orderNew(fresh: string[], opts: QueueOptions, spec: DifficultySpec, now
 
   // Tier bias needs to know each item's tier, and ids do not carry it, so
   // without meta there is nothing to bias on — skip rather than guess.
-  if (meta && spec.tierBias !== 'balanced') {
+  //
+  // `canonical` is exempt, and that exemption is the point rather than an
+  // oversight. Floating tier 1 forward reorders across the whole canon: the
+  // foundational items are scattered through it, so a member on `easy` opened
+  // on Isaiah instead of Genesis. Walking the books in order *is* easy mode's
+  // pedagogy — the frame has to be built front to back — so nothing is allowed
+  // to reorder it. The settings that shuffle or spread have already given up
+  // canonical position, and there the bias costs nothing (#38).
+  if (meta && spec.tierBias !== 'balanced' && spec.newOrder !== 'canonical') {
     const dir = spec.tierBias === 'foundation-first' ? 1 : -1;
     // Array.prototype.sort is stable per spec (ES2019+), which is load-bearing
     // here: it is what makes this a nudge on top of the order above rather

--- a/src/lib/srs.ts
+++ b/src/lib/srs.ts
@@ -104,9 +104,9 @@ export interface QueueOptions {
   sessionLimit: number;
   /**
    * Which cards the session takes, and in what order it opens new ground
-   * (#36, #38). It now drives three things, not one: how hard the cut at the
+   * (#36, #40). It now drives three things, not one: how hard the cut at the
    * session limit leans on per-card ease, how many new cards the limit really
-   * allows, and — the point of #38 — the order unseen material is drawn in.
+   * allows, and — the point of #40 — the order unseen material is drawn in.
    *
    * Absent means today's behaviour exactly: no ease lean, no reordering, the
    * configured new-card limit taken at face value. That is deliberately *not*
@@ -141,7 +141,7 @@ export interface QueueOptions {
  * pulls forward the ones you have nearly got.
  *
  * The magnitude of the lean now comes from the difficulty spec rather than a
- * constant here (#38), so the setting can say *how much* it leans and not just
+ * constant here (#40), so the setting can say *how much* it leans and not just
  * which way. It is still measured in days of borrowed urgency, and still kept
  * small enough that a badly overdue card leads regardless — the queue's first
  * duty is that nothing sails past its due date unreviewed.
@@ -188,20 +188,20 @@ export function buildQueue(
   // The difficulty setting leans on that sort (#36): it changes which due
   // cards win the cut. Due cards only — every new card carries the same seeded
   // ease, so there is no signal there to weight on. What decides *which* new
-  // cards get introduced is orderNew (#38), a separate question the ease lean
+  // cards get introduced is orderNew (#40), a separate question the ease lean
   // cannot answer.
   //
   // Presenting: shuffle what survived. The selection above is deterministic,
   // so without this you meet the same cards in the same order every day and
   // start recalling the sequence rather than the answer (#11). Note this is
-  // the presentation shuffle, not #38's: it reorders one session's cards after
+  // the presentation shuffle, not #40's: it reorders one session's cards after
   // the cut, and cannot change which cards were introduced in the first place.
   return shuffle(interleave(picked).slice(0, opts.sessionLimit));
 }
 
 /**
  * Choose which unseen cards this session introduces, and take the difficulty's
- * share of them (#38).
+ * share of them (#40).
  *
  * The complaint this answers: "build the frame is great in going through all of
  * the books but it's in order — for hard mode it's too easy to predict." It was
@@ -242,7 +242,7 @@ function orderNew(fresh: string[], opts: QueueOptions, spec: DifficultySpec, now
   // on Isaiah instead of Genesis. Walking the books in order *is* easy mode's
   // pedagogy — the frame has to be built front to back — so nothing is allowed
   // to reorder it. The settings that shuffle or spread have already given up
-  // canonical position, and there the bias costs nothing (#38).
+  // canonical position, and there the bias costs nothing (#40).
   if (meta && spec.tierBias !== 'balanced' && spec.newOrder !== 'canonical') {
     const dir = spec.tierBias === 'foundation-first' ? 1 : -1;
     // Array.prototype.sort is stable per spec (ES2019+), which is load-bearing

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -14,7 +14,7 @@ export interface Settings {
   difficulty: Difficulty;
   /**
    * Whether the daily review draws only from the phase the study plan is
-   * currently in (#38).
+   * currently in (#40).
    *
    * Defaults to `true` — unlike `difficulty`, this one deliberately changes
    * behaviour for an account that predates it, because a plan the app ignored
@@ -26,9 +26,9 @@ export interface Settings {
   followPlan: boolean;
   /**
    * ISO date (`YYYY-MM-DD`) the study plan is measured from, or `''` when this
-   * account has never had one recorded (#38).
+   * account has never had one recorded (#40).
    *
-   * The plan was decorative until #38 gated the daily review on it, and the
+   * The plan was decorative until #40 gated the daily review on it, and the
    * moment it stopped being decorative `buildSchedule`'s default start —
    * `new Date()` — became a bug: re-anchoring to "today" on every call puts
    * today inside week 1 forever, so the plan could never advance past Phase 1.

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -12,6 +12,39 @@ export interface Settings {
    * so a store written before #36 back-fills to no change at all.
    */
   difficulty: Difficulty;
+  /**
+   * Whether the daily review draws only from the phase the study plan is
+   * currently in (#38).
+   *
+   * Defaults to `true` — unlike `difficulty`, this one deliberately changes
+   * behaviour for an account that predates it, because a plan the app ignored
+   * was the complaint. A store written before this key back-fills to on, the
+   * same way `difficulty` back-fills to `medium`: every reader trusts Settings
+   * to be complete, so the gap is closed on the way in rather than guessed at
+   * each call site.
+   */
+  followPlan: boolean;
+  /**
+   * ISO date (`YYYY-MM-DD`) the study plan is measured from, or `''` when this
+   * account has never had one recorded (#38).
+   *
+   * The plan was decorative until #38 gated the daily review on it, and the
+   * moment it stopped being decorative `buildSchedule`'s default start —
+   * `new Date()` — became a bug: re-anchoring to "today" on every call puts
+   * today inside week 1 forever, so the plan could never advance past Phase 1.
+   * A schedule is only meaningful relative to a fixed origin, so the origin has
+   * to be a stored fact rather than a re-derived one.
+   *
+   * Unlike `difficulty` and `followPlan`, the sensible default is not a
+   * constant: it is "when this member actually started", which is only knowable
+   * per-store. So the default here is the empty sentinel and the real answer is
+   * derived by `planStartOf` in store-ops.ts, which reads the review log. The
+   * spread-under-defaults in both hooks still applies — a store written before
+   * this key resolves to `''` rather than `undefined`, which keeps Settings
+   * complete for every reader and puts the "not recorded" case in one shape
+   * instead of two.
+   */
+  planStart: string;
 }
 
 export interface SessionLog {
@@ -34,6 +67,10 @@ export const DEFAULT_SETTINGS: Settings = {
   newLimit: 20,
   sessionLimit: 60,
   difficulty: 'medium',
+  followPlan: true,
+  // Empty on purpose — see `Settings.planStart`. A literal date here would be
+  // wrong for everybody the moment it was written; `planStartOf` resolves it.
+  planStart: '',
 };
 
 export function emptyStore(): Store {

--- a/src/lib/store-ops.ts
+++ b/src/lib/store-ops.ts
@@ -26,7 +26,7 @@ const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
  * The date the study plan is measured from — the other end of the interval
- * `examTimeOf` gives, and the fix for #38.
+ * `examTimeOf` gives, and the fix for #40.
  *
  * `buildSchedule` defaults its start to `new Date()`, which was harmless while
  * the plan was only drawn on screen and fatal once the daily review began

--- a/src/lib/store-ops.ts
+++ b/src/lib/store-ops.ts
@@ -21,6 +21,52 @@ export function daysLeftUntil(examTime: number, now = Date.now()): number {
   return Math.max(0, Math.ceil((examTime - now) / DAY_MS));
 }
 
+/** `YYYY-MM-DD`, the only shape `planStart` and `SessionLog.date` are ever written in. */
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * The date the study plan is measured from — the other end of the interval
+ * `examTimeOf` gives, and the fix for #38.
+ *
+ * `buildSchedule` defaults its start to `new Date()`, which was harmless while
+ * the plan was only drawn on screen and fatal once the daily review began
+ * filtering on it: re-anchoring to today on every call keeps today inside week
+ * 1 forever, so `currentPhase` answered Phase 1 for every member on every day
+ * until the exam passed. Anchoring needs a fact that does not move, so it lives
+ * here beside `examTimeOf` rather than being re-guessed at each call site.
+ *
+ * Three sources, in order of how much they know:
+ *
+ * 1. `settings.planStart`, when it has been recorded. An explicit answer wins,
+ *    including one deliberately set in the past or the future.
+ * 2. The earliest day in the review log. This is the derivation for every store
+ *    that predates the key, and it is the right one: a member who has been
+ *    studying for six weeks should be six weeks into the plan, not sent back to
+ *    Phase 1 by an upgrade. `min` over the whole log rather than `log[0]`,
+ *    because an imported store's log carries no ordering guarantee — and ISO
+ *    dates compare correctly as strings, so no parsing is needed to pick it.
+ * 3. Today, for a store with no history at all — a genuinely new member, and
+ *    the E2E fixtures, both of which should start at Phase 1.
+ *
+ * A malformed `planStart` (a hand-edited or foreign import) falls through to
+ * the same chain rather than poisoning the schedule with an Invalid Date.
+ *
+ * Note what this means for `applyReset`, which clears the log but keeps
+ * settings: a member who has never had `planStart` written also loses their
+ * anchor and restarts at Phase 1. That is the intended reading of "start over".
+ */
+export function planStartOf(store: Store, now = new Date()): string {
+  const explicit = store.settings.planStart;
+  if (explicit && ISO_DATE.test(explicit)) return explicit;
+
+  let earliest = '';
+  for (const entry of store.log) {
+    if (!ISO_DATE.test(entry.date)) continue;
+    if (!earliest || entry.date < earliest) earliest = entry.date;
+  }
+  return earliest || todayISO(now);
+}
+
 /** Grade one card and fold the result into today's session log. */
 export function applyAnswer(
   store: Store,

--- a/src/lib/useStore.e2e.ts
+++ b/src/lib/useStore.e2e.ts
@@ -36,6 +36,10 @@ function readStore(): Store {
   if (!raw) return emptyStore();
   try {
     const parsed = JSON.parse(raw) as Partial<Store>;
+    // Settings are spread over the defaults rather than taken whole: a seeded
+    // fixture writes only the keys its test cares about, so anything added
+    // since (difficulty in #36, followPlan in #38) has to back-fill here just
+    // as it does off a Firestore snapshot.
     const base = emptyStore();
     return {
       cards: parsed.cards ?? base.cards,

--- a/src/lib/useStore.e2e.ts
+++ b/src/lib/useStore.e2e.ts
@@ -38,7 +38,7 @@ function readStore(): Store {
     const parsed = JSON.parse(raw) as Partial<Store>;
     // Settings are spread over the defaults rather than taken whole: a seeded
     // fixture writes only the keys its test cares about, so anything added
-    // since (difficulty in #36, followPlan in #38) has to back-fill here just
+    // since (difficulty in #36, followPlan in #40) has to back-fill here just
     // as it does off a Firestore snapshot.
     const base = emptyStore();
     return {

--- a/src/lib/useStore.ts
+++ b/src/lib/useStore.ts
@@ -47,8 +47,9 @@ export function useStore() {
         // A document written before a setting existed simply has no value for
         // it, and every reader downstream trusts Settings to be complete. Fill
         // the gaps from the defaults on the way in, the way importStore and the
-        // E2E hook already do, so #36's difficulty control has something to
-        // show an account that predates it.
+        // E2E hook already do, so #36's difficulty control and #38's
+        // follow-the-plan switch have something to show an account that
+        // predates them.
         const data: Store = { ...saved, settings: { ...DEFAULT_SETTINGS, ...saved.settings } };
         storeRef.current = data;
         setStore(data);

--- a/src/lib/useStore.ts
+++ b/src/lib/useStore.ts
@@ -47,7 +47,7 @@ export function useStore() {
         // A document written before a setting existed simply has no value for
         // it, and every reader downstream trusts Settings to be complete. Fill
         // the gaps from the defaults on the way in, the way importStore and the
-        // E2E hook already do, so #36's difficulty control and #38's
+        // E2E hook already do, so #36's difficulty control and #40's
         // follow-the-plan switch have something to show an account that
         // predates them.
         const data: Store = { ...saved, settings: { ...DEFAULT_SETTINGS, ...saved.settings } };

--- a/src/styles.css
+++ b/src/styles.css
@@ -189,6 +189,25 @@ a:hover { color: var(--color-accent-700); text-decoration: underline; }
   outline-offset: 2px;
 }
 
+/* Said to a screen reader, not drawn (#38).
+   `display: none` would take it away from both, which is the opposite of the
+   point — this is for text the page already communicates by position, colour
+   or layout to everyone who can see it: the shell's one <h1>, the ordering
+   list's move announcements. Clipped to a 1px box so it never reserves space
+   and never wraps a line open. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
 /* ================================================================== layout */
 .app {
   max-width: 1080px;
@@ -493,6 +512,22 @@ input.answer {
 .order-item button:disabled { opacity: 0.3; cursor: not-allowed; }
 .order-item.correct { border-color: var(--color-accent); background: var(--tint-accent); }
 .order-item.wrong { border-color: var(--color-error); background: var(--tint-error); }
+/* The same verdict again, in a channel that survives a colour-blind eye and a
+   monochrome print (#38). Border and tint alone said "right" and "wrong" in
+   hue only — red and green at that, the one pair most likely to read as the
+   same grey. The glyph carries its own `role="img"` label, so it is a third
+   channel as well: shape, position, and spoken text. */
+.order-item .mark {
+  margin-left: auto;
+  flex: none;
+  font-family: var(--font-mono);
+  font-style: normal;
+  font-weight: 700;
+  font-size: 13px;
+  line-height: 1;
+}
+.order-item.correct .mark { color: var(--color-accent); }
+.order-item.wrong .mark { color: var(--color-error); }
 
 /* ============================================================ tags / pills */
 .pill,

--- a/src/styles.css
+++ b/src/styles.css
@@ -189,7 +189,7 @@ a:hover { color: var(--color-accent-700); text-decoration: underline; }
   outline-offset: 2px;
 }
 
-/* Said to a screen reader, not drawn (#38).
+/* Said to a screen reader, not drawn (#40).
    `display: none` would take it away from both, which is the opposite of the
    point — this is for text the page already communicates by position, colour
    or layout to everyone who can see it: the shell's one <h1>, the ordering
@@ -513,7 +513,7 @@ input.answer {
 .order-item.correct { border-color: var(--color-accent); background: var(--tint-accent); }
 .order-item.wrong { border-color: var(--color-error); background: var(--tint-error); }
 /* The same verdict again, in a channel that survives a colour-blind eye and a
-   monochrome print (#38). Border and tint alone said "right" and "wrong" in
+   monochrome print (#40). Border and tint alone said "right" and "wrong" in
    hue only — red and green at that, the one pair most likely to read as the
    same grey. The glyph carries its own `role="img"` label, so it is a third
    channel as well: shape, position, and spoken text. */

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { allItems } from '../lib/generate';
 import { isDue, isNew, strength } from '../lib/srs';
-import { buildSchedule } from '../data/plan';
+import { currentPhase, currentWeek } from '../data/plan';
 import { TOPIC_LABELS, type Topic } from '../data/types';
 import type { StoreApi } from '../lib/useStore';
 import { todayISO } from '../lib/storage';
+import { planStartOf } from '../lib/store-ops';
 import { Card, CountUp, Meter, sx } from '../ui';
 
 export default function Dashboard({ api, go }: { api: StoreApi; go: (tab: string) => void }) {
@@ -52,11 +53,30 @@ export default function Dashboard({ api, go }: { api: StoreApi; go: (tab: string
       .sort((a, b) => a.pct - b.pct);
   }, [cards, items]);
 
-  const schedule = useMemo(() => buildSchedule(store.settings.examDate), [store.settings.examDate]);
-  const currentWeek = schedule.find((w) => {
-    const now = new Date();
-    return now >= w.start && now <= new Date(w.end.getTime() + 86_400_000);
-  }) ?? schedule[0];
+  // "Which week is it?" is one question with one answer (#38), and the daily
+  // review now depends on it too — so it lives in data/plan.ts rather than
+  // being re-derived here.
+  //
+  // The anchor is the member's stored plan start, not today. Passing `now` here
+  // is what pinned this card to "Week 1 — Build the Frame" for everyone, on
+  // every day of the plan; the schedule only advances if it is measured from a
+  // fixed origin.
+  const planStart = planStartOf(store);
+  const week = useMemo(
+    () => currentWeek(store.settings.examDate, planStart),
+    [store.settings.examDate, planStart],
+  );
+  // The old fall back to `buildSchedule(...)[0]` is gone: `currentWeek` now
+  // clamps to the schedule's own ends, so it only returns null when there are
+  // no weeks at all (an anchor past the exam date). Naming "Week 1 — Build the
+  // Frame" in that case would contradict `currentPhase`, which answers Phase 5
+  // for exactly the same store — and the review queue below this card obeys
+  // `currentPhase`. So the phase comes from the same helper the queue uses, and
+  // only the week pill — the part with genuinely nothing to say — drops out.
+  const phase = useMemo(
+    () => currentPhase(store.settings.examDate, planStart),
+    [store.settings.examDate, planStart],
+  );
 
   const streak = useMemo(() => {
     const dates = new Set(store.log.filter((l) => l.reviewed > 0).map((l) => l.date));
@@ -90,9 +110,9 @@ export default function Dashboard({ api, go }: { api: StoreApi; go: (tab: string
         <Card corners>
           <div className="spread">
             <div>
-              <span className="pill accent">{currentWeek?.label ?? 'Week 1'}</span>
-              <h2 style={{ margin: '10px 0 4px' }}>{currentWeek?.phase.name}</h2>
-              <p className="small muted" style={{ maxWidth: 620, marginBottom: 0 }}>{currentWeek?.phase.goal}</p>
+              {week && <span className="pill accent">{week.label}</span>}
+              <h2 style={{ margin: '10px 0 4px' }}>{phase.name}</h2>
+              <p className="small muted" style={{ maxWidth: 620, marginBottom: 0 }}>{phase.goal}</p>
             </div>
           </div>
           <div className="row" style={{ marginTop: 18 }}>

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -53,7 +53,7 @@ export default function Dashboard({ api, go }: { api: StoreApi; go: (tab: string
       .sort((a, b) => a.pct - b.pct);
   }, [cards, items]);
 
-  // "Which week is it?" is one question with one answer (#38), and the daily
+  // "Which week is it?" is one question with one answer (#40), and the daily
   // review now depends on it too — so it lives in data/plan.ts rather than
   // being re-derived here.
   //

--- a/src/views/Plan.tsx
+++ b/src/views/Plan.tsx
@@ -10,7 +10,7 @@ const fmt = (d: Date) => d.toLocaleDateString(undefined, { month: 'short', day: 
 export default function Plan({ api }: { api: StoreApi }) {
   const { store, updateSettings, daysLeft } = api;
   // The schedule is drawn from the member's stored plan start, not from today
-  // (#38). Rebuilding it from `new Date()` on every render was what made every
+  // (#40). Rebuilding it from `new Date()` on every render was what made every
   // week between the start and now silently disappear — the first row always
   // said "this week", so the view could only ever show a plan about to begin.
   const planStart = planStartOf(store);
@@ -19,7 +19,7 @@ export default function Plan({ api }: { api: StoreApi }) {
     [store.settings.examDate, planStart],
   );
   // Which row wears the `now` highlight is the same question the Dashboard and
-  // the daily review ask, so it comes from the one helper (#38) and is matched
+  // the daily review ask, so it comes from the one helper (#40) and is matched
   // by index rather than re-testing the date range row by row.
   const active = useMemo(
     () => currentWeek(store.settings.examDate, planStart),
@@ -65,7 +65,7 @@ export default function Plan({ api }: { api: StoreApi }) {
           ) : (
             schedule.map((w, i) => {
               // Weeks can now genuinely be behind you, which they never could
-              // while the schedule restarted at today (#38). Three states, from
+              // while the schedule restarted at today (#40). Three states, from
               // the one `active` index rather than three date tests: done,
               // current, still to come. Deliberately not a new stylesheet rule
               // — `.week.now` already carries the highlight, and a past week

--- a/src/views/Plan.tsx
+++ b/src/views/Plan.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
-import { buildSchedule, PHASES } from '../data/plan';
+import { buildSchedule, currentWeek, PHASES } from '../data/plan';
 import { TOPIC_LABELS } from '../data/types';
+import { planStartOf } from '../lib/store-ops';
 import type { StoreApi } from '../lib/useStore';
 import { Card, Field, space, sx } from '../ui';
 
@@ -8,8 +9,22 @@ const fmt = (d: Date) => d.toLocaleDateString(undefined, { month: 'short', day: 
 
 export default function Plan({ api }: { api: StoreApi }) {
   const { store, updateSettings, daysLeft } = api;
-  const schedule = useMemo(() => buildSchedule(store.settings.examDate), [store.settings.examDate]);
-  const now = new Date();
+  // The schedule is drawn from the member's stored plan start, not from today
+  // (#38). Rebuilding it from `new Date()` on every render was what made every
+  // week between the start and now silently disappear — the first row always
+  // said "this week", so the view could only ever show a plan about to begin.
+  const planStart = planStartOf(store);
+  const schedule = useMemo(
+    () => buildSchedule(store.settings.examDate, new Date(`${planStart}T00:00:00`)),
+    [store.settings.examDate, planStart],
+  );
+  // Which row wears the `now` highlight is the same question the Dashboard and
+  // the daily review ask, so it comes from the one helper (#38) and is matched
+  // by index rather than re-testing the date range row by row.
+  const active = useMemo(
+    () => currentWeek(store.settings.examDate, planStart),
+    [store.settings.examDate, planStart],
+  );
 
   return (
     <div className="stack-in">
@@ -33,7 +48,8 @@ export default function Plan({ api }: { api: StoreApi }) {
           </Field>
         </div>
         <p className="small muted" style={sx({ marginTop: space[3] })}>
-          {daysLeft} days left, split across {schedule.length} weeks. The order matters: the frame
+          {daysLeft} days left. The plan below runs {schedule.length} weeks from the day you
+          started, not from today, so it moves on as the weeks pass. The order matters: the frame
           first, then content, then connections, then mixed review. Detail learned before the frame
           has nothing to attach to.
         </p>
@@ -48,16 +64,23 @@ export default function Plan({ api }: { api: StoreApi }) {
             </p>
           ) : (
             schedule.map((w, i) => {
-              const active = now >= w.start && now <= new Date(w.end.getTime() + 86_400_000);
+              // Weeks can now genuinely be behind you, which they never could
+              // while the schedule restarted at today (#38). Three states, from
+              // the one `active` index rather than three date tests: done,
+              // current, still to come. Deliberately not a new stylesheet rule
+              // — `.week.now` already carries the highlight, and a past week
+              // only needs to read as receded, so it dims and says so.
+              const isNow = w.index === active?.index;
+              const isPast = active != null && w.index < active.index;
               return (
                 <div
-                  className={`week${active ? ' now' : ''} item-in`}
-                  style={sx({ '--stagger-i': i })}
+                  className={`week${isNow ? ' now' : ''} item-in`}
+                  style={sx({ '--stagger-i': i, opacity: isPast ? 0.5 : undefined })}
                   key={w.index}
                 >
                   <div>
                     <div className="when">{fmt(w.start)} – {fmt(w.end)}</div>
-                    <div className="tiny muted">{w.label}</div>
+                    <div className="tiny muted">{w.label}{isPast ? ' · past' : ''}</div>
                   </div>
                   <div>
                     <strong className="small">{w.phase.name.replace(/^Phase \d+ — /, '')}</strong>

--- a/src/views/Progress.tsx
+++ b/src/views/Progress.tsx
@@ -58,7 +58,7 @@ export default function Progress({ api }: { api: StoreApi }) {
     const a = document.createElement('a');
     a.href = url;
     a.download = `scripture-mastery-progress-${new Date().toISOString().slice(0, 10)}.json`;
-    // Two browser rules this used to break, both silently (#38). Firefox will
+    // Two browser rules this used to break, both silently (#40). Firefox will
     // not honour a programmatic click on an anchor that was never in the
     // document, so the download simply did not happen — no error, no file.
     // And revoking the object URL on the same tick can outrun the download

--- a/src/views/Progress.tsx
+++ b/src/views/Progress.tsx
@@ -58,8 +58,17 @@ export default function Progress({ api }: { api: StoreApi }) {
     const a = document.createElement('a');
     a.href = url;
     a.download = `scripture-mastery-progress-${new Date().toISOString().slice(0, 10)}.json`;
+    // Two browser rules this used to break, both silently (#38). Firefox will
+    // not honour a programmatic click on an anchor that was never in the
+    // document, so the download simply did not happen — no error, no file.
+    // And revoking the object URL on the same tick can outrun the download
+    // Safari has only just started, which loses the file the same quiet way.
+    // So: attach, click, detach, and let the URL go on the next turn of the
+    // event loop, by which point every browser has taken its copy.
+    document.body.appendChild(a);
     a.click();
-    URL.revokeObjectURL(url);
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
   }
 
   function doImport(file: File) {

--- a/src/views/Quiz.tsx
+++ b/src/views/Quiz.tsx
@@ -15,7 +15,7 @@ import type { StoreApi } from '../lib/useStore';
 type Scope = 'plan' | 'all' | 'OT' | 'NT' | 'essentials' | 'starred' | 'weak';
 
 /**
- * The plan-aware scope (#38).
+ * The plan-aware scope (#40).
  *
  * The daily review now follows the study plan; a quiz is where you go to test
  * yourself on demand, so it keeps every other scope untouched and simply adds
@@ -45,7 +45,7 @@ export default function Quiz({ api }: { api: StoreApi }) {
   /**
    * The anchor is the persisted plan start rather than today: a schedule that
    * begins today always puts today in week 1, which is what pinned the whole
-   * app to Phase 1 (#38). `currentPhase` is total, so there is always a phase
+   * app to Phase 1 (#40). `currentPhase` is total, so there is always a phase
    * to point the quiz at.
    */
   const phase = currentPhase(store.settings.examDate, planStartOf(store));

--- a/src/views/Quiz.tsx
+++ b/src/views/Quiz.tsx
@@ -4,12 +4,27 @@ import QuestionCard from '../components/QuestionCard';
 import { allItems, ITEMS_BY_ID } from '../lib/generate';
 import { ESSENTIAL_ITEM_IDS } from '../lib/generate-essentials';
 import { BOOKS } from '../data/books';
+import { currentPhase } from '../data/plan';
+import { planStartOf } from '../lib/store-ops';
+import { planScopeIds } from '../lib/plan-scope';
 import { TOPIC_LABELS, type Topic } from '../data/types';
 import { shuffle } from '../lib/rng';
 import { strength, type Grade } from '../lib/srs';
 import type { StoreApi } from '../lib/useStore';
 
-type Scope = 'all' | 'OT' | 'NT' | 'essentials' | 'starred' | 'weak';
+type Scope = 'plan' | 'all' | 'OT' | 'NT' | 'essentials' | 'starred' | 'weak';
+
+/**
+ * The plan-aware scope (#38).
+ *
+ * The daily review now follows the study plan; a quiz is where you go to test
+ * yourself on demand, so it keeps every other scope untouched and simply adds
+ * the plan as one more thing you can point it at. It leads the list because it
+ * is the answer to "what should I be drilling right now?" — and it is dropped
+ * entirely, not greyed out, when the quiz date has passed and there is no
+ * current phase to name.
+ */
+const PLAN_SCOPE_LABEL = 'This week’s plan';
 
 export default function Quiz({ api }: { api: StoreApi }) {
   const { store, cards, answer, toggleStar } = api;
@@ -27,10 +42,20 @@ export default function Quiz({ api }: { api: StoreApi }) {
   const otIds = useMemo(() => new Set(BOOKS.filter((b) => b.testament === 'OT').map((b) => b.id)), []);
   const ntIds = useMemo(() => new Set(BOOKS.filter((b) => b.testament === 'NT').map((b) => b.id)), []);
 
+  /**
+   * The anchor is the persisted plan start rather than today: a schedule that
+   * begins today always puts today in week 1, which is what pinned the whole
+   * app to Phase 1 (#38). `currentPhase` is total, so there is always a phase
+   * to point the quiz at.
+   */
+  const phase = currentPhase(store.settings.examDate, planStartOf(store));
+  const planIds = useMemo(() => planScopeIds(phase, items), [phase, items]);
+
   const pool = useMemo(() => {
     let out = items;
     if (topic !== 'all') out = out.filter((i) => i.topic === topic);
     if (book !== 'all') out = out.filter((i) => i.book === book);
+    if (scope === 'plan') out = out.filter((i) => planIds.has(i.id));
     if (scope === 'OT') out = out.filter((i) => i.book && otIds.has(i.book));
     if (scope === 'NT') out = out.filter((i) => i.book && ntIds.has(i.book));
     if (scope === 'essentials') out = out.filter((i) => ESSENTIAL_ITEM_IDS.has(i.id));
@@ -41,7 +66,7 @@ export default function Quiz({ api }: { api: StoreApi }) {
         .sort((a, b) => strength(cards[a.id]) - strength(cards[b.id]));
     }
     return out;
-  }, [items, topic, book, scope, store.starred, cards, otIds, ntIds]);
+  }, [items, topic, book, scope, planIds, store.starred, cards, otIds, ntIds]);
 
   function start() {
     const picked = scope === 'weak' ? pool.slice(0, length) : shuffle(pool).slice(0, length);
@@ -108,6 +133,7 @@ export default function Quiz({ api }: { api: StoreApi }) {
                 value={scope}
                 onChange={setScope}
                 options={[
+                  { label: PLAN_SCOPE_LABEL, value: 'plan' as const },
                   { label: 'Everything', value: 'all' },
                   { label: 'Old Testament', value: 'OT' },
                   { label: 'New Testament', value: 'NT' },

--- a/src/views/Review.tsx
+++ b/src/views/Review.tsx
@@ -74,6 +74,12 @@ export default function Review({ api }: { api: StoreApi }) {
    * while `start` would happily widen and hand over a full session. The button
    * has to follow the queue's rule, not the plates'.
    */
+  /** The new-card limit after the difficulty's own scaling — what buildQueue will take. */
+  const newToday = Math.max(
+    0,
+    Math.round(store.settings.newLimit * specFor(store.settings.difficulty).newLimitFactor),
+  );
+
   const counts = useMemo(() => {
     const now = Date.now();
     const inScope = scopedIds ? new Set(scopedIds) : null;
@@ -184,7 +190,13 @@ export default function Review({ api }: { api: StoreApi }) {
             <span className="k">Due now</span>
           </Card>
           <Card className="stat">
-            <span className="n"><CountUp value={Math.min(counts.fresh, store.settings.newLimit)} /></span>
+            {/*
+              * The plate has to promise the number the session will actually
+              * take. The setting scales the new-card limit — hard introduces
+              * half again as much — so reading the raw setting here would say
+              * 20 and then deal 30 (#38).
+              */}
+            <span className="n"><CountUp value={Math.min(counts.fresh, newToday)} /></span>
             <span className="k">New today</span>
           </Card>
           <Card className="stat">

--- a/src/views/Review.tsx
+++ b/src/views/Review.tsx
@@ -1,9 +1,28 @@
 import { useMemo, useState } from 'react';
 import QuestionCard from '../components/QuestionCard';
 import { allItems, ITEMS_BY_ID } from '../lib/generate';
-import { buildQueue, isDue, isNew, type Grade } from '../lib/srs';
+import { currentPhase } from '../data/plan';
+import { planStartOf } from '../lib/store-ops';
+import { planScopeIds, withTopUp } from '../lib/plan-scope';
+import { specFor } from '../lib/difficulty';
+import { buildQueue, isDue, isNew, type ItemMeta, type Grade } from '../lib/srs';
+import { todayISO } from '../lib/storage';
 import type { StoreApi } from '../lib/useStore';
+import { copy } from '../copy';
 import { Card, Corners, CountUp, Meter, sx, space } from '../ui';
+
+/**
+ * Per-item metadata for the queue builder, built once for the process.
+ *
+ * The bank is ~6,000 items and never changes at runtime, while `cards` changes
+ * on every answer — so this cannot live in a `useMemo` keyed on store state
+ * without rebuilding six thousand objects each time a card is graded.
+ */
+const ITEM_META: Record<string, ItemMeta> = (() => {
+  const meta: Record<string, ItemMeta> = {};
+  for (const item of allItems()) meta[item.id] = { tier: item.tier, book: item.book };
+  return meta;
+})();
 
 export default function Review({ api }: { api: StoreApi }) {
   const { store, cards, answer, toggleStar } = api;
@@ -15,24 +34,107 @@ export default function Review({ api }: { api: StoreApi }) {
   const [requeues, setRequeues] = useState<Record<string, number>>({});
   const [started, setStarted] = useState(false);
 
+  /**
+   * The phase the plan is asking for today, or null when the setting is off.
+   *
+   * `currentPhase` is total — there is no date on which "no phase" is the
+   * honest answer, and a member who has run out of runway belongs in Phase 5's
+   * mixed review rather than nowhere — so the setting is the only thing that
+   * can switch the plan off here. The anchor is the persisted plan start, not
+   * today: passing `new Date()` is what pinned every member to Phase 1
+   * forever, because today is always inside week 1 of a schedule that begins
+   * today (#38).
+   *
+   * Every decision below reads this one value, so the screen cannot claim to
+   * be following a phase the queue is ignoring.
+   */
+  const phase = store.settings.followPlan
+    ? currentPhase(store.settings.examDate, planStartOf(store))
+    : null;
+
+  /**
+   * The ids the plan puts in scope today, in the bank's own order.
+   *
+   * Shared by the counts and the queue on purpose: the idle screen promises a
+   * number of due cards and then hands you a session, and those two have to be
+   * counting the same material or the promise is a lie.
+   */
+  const scopedIds = useMemo(() => {
+    if (!phase) return null;
+    const inScope = planScopeIds(phase, items);
+    return items.filter((i) => inScope.has(i.id)).map((i) => i.id);
+  }, [phase, items]);
+
+  /**
+   * The three plates, counted inside whatever the session will actually draw
+   * from — plus one figure that is deliberately counted outside it.
+   *
+   * `bankActionable` exists because the plates alone would lock the reader out:
+   * a phase whose material is all seen and none of it yet due shows zeroes,
+   * while `start` would happily widen and hand over a full session. The button
+   * has to follow the queue's rule, not the plates'.
+   */
   const counts = useMemo(() => {
     const now = Date.now();
-    let due = 0, fresh = 0;
+    const inScope = scopedIds ? new Set(scopedIds) : null;
+    let due = 0, fresh = 0, total = 0, bankActionable = 0;
     for (const it of items) {
       const c = cards[it.id];
+      const actionable = isNew(c) || isDue(c, now);
+      if (actionable) bankActionable++;
+      if (inScope && !inScope.has(it.id)) continue;
+      total++;
       if (isNew(c)) fresh++;
       else if (isDue(c, now)) due++;
     }
-    return { due, fresh, total: items.length };
-  }, [cards, items]);
+    return { due, fresh, total, bankActionable };
+  }, [cards, items, scopedIds]);
 
-  function start() {
-    const q = buildQueue(items.map((i) => i.id), cards, {
-      newLimit: store.settings.newLimit,
-      sessionLimit: store.settings.sessionLimit,
-      difficulty: store.settings.difficulty,
-    });
-    setQueue(q);
+  function start(ignorePlan = false) {
+    const allIds = items.map((i) => i.id);
+    const { sessionLimit } = store.settings;
+
+    /**
+     * Widening is measured on the cards a session could actually contain, not
+     * on the raw scope.
+     *
+     * `withTopUp` takes id lists, and a phase's raw scope always holds several
+     * hundred items — so handing it the unfiltered lists would mean the top-up
+     * never fires, and the starvation it exists to prevent is not "the phase is
+     * small" but "the phase is exhausted": late in a phase everything in it has
+     * been seen and nothing is due yet. Filtering to due-or-new first is what
+     * makes the widening answer that. It is free of side effects on the queue —
+     * buildQueue discards anything that is neither due nor new anyway, and the
+     * pre-filter preserves order, so the new-card cut is untouched.
+     */
+    const actionable = (id: string) => isNew(cards[id]) || isDue(cards[id]);
+    const ids =
+      ignorePlan || !scopedIds
+        ? allIds
+        : withTopUp(scopedIds.filter(actionable), allIds.filter(actionable), sessionLimit);
+
+    const build = (from: string[]) =>
+      buildQueue(from, cards, {
+        newLimit: store.settings.newLimit,
+        sessionLimit,
+        difficulty: store.settings.difficulty,
+        meta: ITEM_META,
+        // Seeded per day rather than per session: reloading the page mid-review
+        // must not reshuffle the new cards out from under you, but tomorrow's
+        // session should not open on the same order as today's.
+        seed: todayISO(),
+      });
+
+    // The second starvation guard, and the one that catches what `withTopUp`
+    // structurally cannot. The top-up counts candidates; buildQueue applies the
+    // new-card limit *after* it, so a phase holding hundreds of untouched cards
+    // and nothing due looks well stocked to the top-up and still yields an
+    // empty queue once `newLimit` is 0. An empty session is the single output
+    // this feature must never produce — a calendar may reorder your study, not
+    // cancel it — so the plan filter drops entirely rather than hand back
+    // nothing.
+    const q = build(ids);
+    setQueue(q.length === 0 && !ignorePlan && scopedIds ? build(allIds) : q);
     setPos(0);
     setTally({ right: 0, wrong: 0 });
     setRequeues({});
@@ -45,7 +147,11 @@ export default function Review({ api }: { api: StoreApi }) {
     setTally((t) => (g === 0 ? { ...t, wrong: t.wrong + 1 } : { ...t, right: t.right + 1 }));
     // A failed card comes back at the end of the session rather than disappearing,
     // but only twice — otherwise a card you cannot get keeps the session open forever.
-    if (g === 0 && (requeues[id] ?? 0) < 2) {
+    //
+    // On hard it does not come back at all (#38): a second look minutes after
+    // the first is recognition, not recall, and hard's whole premise is that you
+    // meet the card again cold. The cap still governs wherever requeueing is on.
+    if (g === 0 && specFor(store.settings.difficulty).requeueMissed && (requeues[id] ?? 0) < 2) {
       setRequeues((r) => ({ ...r, [id]: (r[id] ?? 0) + 1 }));
       setQueue((q) => [...q, id]);
     }
@@ -53,7 +159,9 @@ export default function Review({ api }: { api: StoreApi }) {
   }
 
   if (!started) {
-    const canStart = counts.due + counts.fresh > 0;
+    const inPhase = counts.due + counts.fresh;
+    const canStart = inPhase > 0 || (phase !== null && counts.bankActionable > 0);
+    const widening = phase !== null && inPhase === 0 && counts.bankActionable > 0;
     return (
       <div className="section screen" key="idle">
         <h2>Daily Review</h2>
@@ -61,6 +169,15 @@ export default function Review({ api }: { api: StoreApi }) {
           Spaced repetition over everything you have unlocked. Cards you miss come back sooner;
           cards you know get pushed out — but never past your exam date.
         </p>
+        {phase && (
+          // Said before the session starts, not discovered inside it: a reader
+          // who does not know the queue is scoped will read a short session as
+          // a bug, and the way out has to be one click from the same screen.
+          <p className="small" style={sx({ marginTop: space[3] })}>
+            {copy.settings.followPlan.activeOn(phase.name)}{' '}
+            <span className="muted">{phase.goal}</span>
+          </p>
+        )}
         <div className="grid three stack-in" style={sx({ margin: `${space[6]} 0` })}>
           <Card className="stat">
             <span className="n"><CountUp value={counts.due} /></span>
@@ -75,9 +192,21 @@ export default function Review({ api }: { api: StoreApi }) {
             <span className="k">Seen so far</span>
           </Card>
         </div>
-        <button className="btn primary" onClick={start} disabled={!canStart}>
-          Start review session
-        </button>
+        <div className="row">
+          <button className="btn primary" onClick={() => start()} disabled={!canStart}>
+            Start review session
+          </button>
+          {phase && (
+            <button className="btn" onClick={() => start(true)}>
+              {copy.settings.followPlan.studyEverything}
+            </button>
+          )}
+        </div>
+        {widening && (
+          <p className="small muted" style={sx({ marginTop: space[3] })}>
+            Nothing is left waiting in this phase, so today’s session widens to the rest of the bank.
+          </p>
+        )}
         {!canStart && (
           <p className="small muted" style={sx({ marginTop: space[3] })}>
             Nothing is due right now. Take a mixed quiz instead, or raise your daily new-card limit in Progress.
@@ -111,7 +240,7 @@ export default function Review({ api }: { api: StoreApi }) {
           </Card>
         </div>
         <div className="row">
-          <button className="btn primary" onClick={start}>Another session</button>
+          <button className="btn primary" onClick={() => start()}>Another session</button>
           <button className="btn" onClick={() => setStarted(false)}>Done</button>
         </div>
       </div>
@@ -125,7 +254,23 @@ export default function Review({ api }: { api: StoreApi }) {
       <div style={sx({ marginBottom: space[4] })}>
         <Meter value={pos} max={queue.length} label={`${pos} of ${queue.length} answered`} />
       </div>
-      <div className="card-swap" key={item.id} style={sx({ position: 'relative' })}>
+      {/*
+        Keyed on the queue position, not the item id (#38).
+
+        A missed card is appended to the queue, and when it was the last entry
+        the copy lands immediately after itself: `queue[pos + 1] === queue[pos]`.
+        Keyed by id, that key does not change, so React reuses the mounted
+        QuestionCard — and QuestionCard resets itself from an effect keyed on
+        `item.id`, which does not change either. The card came back still
+        revealed, still showing "Not quite" with its answer and a Continue
+        button, and pressing Continue graded the same miss a second and third
+        time: three reps, three lapses and three log entries from one miss,
+        one short of the four that mark an item a leech.
+        Position is unique per step by construction, so the same id repeating
+        back-to-back still remounts the card and asks it cold — which is the
+        only reason to requeue it at all.
+      */}
+      <div className="card-swap" key={pos} style={sx({ position: 'relative' })}>
         <Corners />
         <QuestionCard
           item={item}

--- a/src/views/Review.tsx
+++ b/src/views/Review.tsx
@@ -43,7 +43,7 @@ export default function Review({ api }: { api: StoreApi }) {
    * can switch the plan off here. The anchor is the persisted plan start, not
    * today: passing `new Date()` is what pinned every member to Phase 1
    * forever, because today is always inside week 1 of a schedule that begins
-   * today (#38).
+   * today (#40).
    *
    * Every decision below reads this one value, so the screen cannot claim to
    * be following a phase the queue is ignoring.
@@ -154,7 +154,7 @@ export default function Review({ api }: { api: StoreApi }) {
     // A failed card comes back at the end of the session rather than disappearing,
     // but only twice — otherwise a card you cannot get keeps the session open forever.
     //
-    // On hard it does not come back at all (#38): a second look minutes after
+    // On hard it does not come back at all (#40): a second look minutes after
     // the first is recognition, not recall, and hard's whole premise is that you
     // meet the card again cold. The cap still governs wherever requeueing is on.
     if (g === 0 && specFor(store.settings.difficulty).requeueMissed && (requeues[id] ?? 0) < 2) {
@@ -194,7 +194,7 @@ export default function Review({ api }: { api: StoreApi }) {
               * The plate has to promise the number the session will actually
               * take. The setting scales the new-card limit — hard introduces
               * half again as much — so reading the raw setting here would say
-              * 20 and then deal 30 (#38).
+              * 20 and then deal 30 (#40).
               */}
             <span className="n"><CountUp value={Math.min(counts.fresh, newToday)} /></span>
             <span className="k">New today</span>
@@ -267,7 +267,7 @@ export default function Review({ api }: { api: StoreApi }) {
         <Meter value={pos} max={queue.length} label={`${pos} of ${queue.length} answered`} />
       </div>
       {/*
-        Keyed on the queue position, not the item id (#38).
+        Keyed on the queue position, not the item id (#40).
 
         A missed card is appended to the queue, and when it was the last entry
         the copy lands immediately after itself: `queue[pos + 1] === queue[pos]`.

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -13,6 +13,7 @@
  * the boot splash flashes the wrong theme. The panel is a shared surface for the
  * two, not a merge of them.
  */
+import { useState } from 'react';
 import { DIFFICULTIES, type Difficulty } from '../data/types';
 import { useThemeMode, type ThemeMode } from '../lib/theme';
 import type { StoreApi } from '../lib/useStore';
@@ -31,10 +32,98 @@ const DIFFICULTY_OPTIONS = DIFFICULTIES.map((value) => ({
   value,
 }));
 
+/**
+ * The follow-the-plan switch is a boolean, but it is rendered as the same
+ * two-option Segmented the rest of this panel uses (#38) rather than a
+ * checkbox: a checkbox states one side and leaves the other implied, and the
+ * choice here is genuinely between two study strategies, not between a
+ * behaviour and its absence.
+ */
+const FOLLOW_PLAN_OPTIONS = [
+  { label: copy.settings.followPlan.options.on, value: 'on' },
+  { label: copy.settings.followPlan.options.off, value: 'off' },
+] as const;
+
+/**
+ * The bounds the two number fields already advertise through `min`/`max` (#38).
+ *
+ * They live here rather than inline on the inputs alone because until now they
+ * were decorative: a `min` attribute stops the spinner and the browser's own
+ * validity check, and stops nothing at all about what `onChange` writes to the
+ * store. One constant feeds both the attribute and the clamp so the promise the
+ * control makes and the rule it enforces cannot drift apart.
+ */
+const LIMITS = {
+  newLimit: { min: 5, max: 100 },
+  sessionLimit: { min: 10, max: 300 },
+} as const;
+
+/**
+ * The value to commit for a limit field, or null for "do not commit anything".
+ *
+ * `Number('')` is 0 and `Number('-')` is NaN, and both used to go straight into
+ * the store (#38). A committed `sessionLimit: 0` makes `buildQueue` return an
+ * empty array, so "Start review session" jumped to "Session complete — 0
+ * answered"; and select-all-then-retype produces exactly that empty string as
+ * an intermediate, so it took no misuse at all to hit it.
+ */
+function limitToCommit(raw: string, bounds: { min: number; max: number }): number | null {
+  if (raw.trim() === '') return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return null;
+  return Math.min(bounds.max, Math.max(bounds.min, Math.round(n)));
+}
+
+/**
+ * Whether a date string is one the rest of the app can do arithmetic on.
+ *
+ * An empty `examDate` is the dangerous one, and quietly so: `examTimeOf` builds
+ * `new Date('T23:59:59')` from it, which is NaN, and in `srs.grade` the exam
+ * clamp is written `daysLeft = Math.max(0, Math.ceil((examTime - now) / DAY))`
+ * followed by `daysLeft > 0`. NaN fails that comparison silently, so the clamp
+ * — the one place this app deliberately departs from SM-2, guaranteeing every
+ * card is seen at least once more before the quiz — simply stops applying, and
+ * cards start scheduling past the exam date never to return. Nothing on screen
+ * says so beyond a "NaN days until Invalid Date" in the header (#38).
+ */
+function isUsableExamDate(raw: string): boolean {
+  return raw !== '' && Number.isFinite(new Date(`${raw}T23:59:59`).getTime());
+}
+
 export default function Settings({ api }: { api: StoreApi }) {
   const { store, updateSettings } = api;
   const [themeMode, setTheme] = useThemeMode();
-  const { display, difficulty, study } = copy.settings;
+  const { display, difficulty, followPlan, study } = copy.settings;
+
+  /**
+   * What the three inputs *show*, which is deliberately not the same thing as
+   * what the store holds (#38).
+   *
+   * Clamping the rendered value instead would make the fields miserable to
+   * edit: clear "60" to type "120" and a store-driven value snaps you back to
+   * "10" mid-keystroke. So the draft is free — empty, half-typed, out of range
+   * — and only the *commit* is guarded. The draft seeds from the store on mount
+   * and re-syncs on blur, which is where an ignored or clamped entry visibly
+   * settles onto the value that was actually saved. Mount is enough of a seed
+   * because App unmounts each view on tab switch, so re-entering Settings
+   * always reads fresh state.
+   */
+  const [draft, setDraft] = useState({
+    examDate: store.settings.examDate,
+    newLimit: String(store.settings.newLimit),
+    sessionLimit: String(store.settings.sessionLimit),
+  });
+
+  function editLimit(key: 'newLimit' | 'sessionLimit', raw: string) {
+    setDraft((d) => ({ ...d, [key]: raw }));
+    const next = limitToCommit(raw, LIMITS[key]);
+    if (next !== null) updateSettings({ [key]: next });
+  }
+
+  /** Show what was saved, once the field is no longer being typed into. */
+  function settle(key: 'examDate' | 'newLimit' | 'sessionLimit') {
+    setDraft((d) => ({ ...d, [key]: String(store.settings[key]) }));
+  }
 
   return (
     <div className="stack-in">
@@ -52,8 +141,16 @@ export default function Settings({ api }: { api: StoreApi }) {
                 className="ctl"
                 type="date"
                 style={{ width: '100%' }}
-                value={store.settings.examDate}
-                onChange={(e) => updateSettings({ examDate: e.target.value })}
+                value={draft.examDate}
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  setDraft((d) => ({ ...d, examDate: raw }));
+                  // A cleared or half-entered date is a state of the input, not
+                  // an instruction to un-set the quiz date; the field keeps it
+                  // on screen and the store keeps the last usable one.
+                  if (isUsableExamDate(raw)) updateSettings({ examDate: raw });
+                }}
+                onBlur={() => settle('examDate')}
               />
             </Field>
             <Field label={study.newLimit} htmlFor="nl">
@@ -61,11 +158,12 @@ export default function Settings({ api }: { api: StoreApi }) {
                 id="nl"
                 className="ctl"
                 type="number"
-                min={5}
-                max={100}
+                min={LIMITS.newLimit.min}
+                max={LIMITS.newLimit.max}
                 style={{ width: '100%' }}
-                value={store.settings.newLimit}
-                onChange={(e) => updateSettings({ newLimit: Number(e.target.value) })}
+                value={draft.newLimit}
+                onChange={(e) => editLimit('newLimit', e.target.value)}
+                onBlur={() => settle('newLimit')}
               />
             </Field>
             <Field label={study.sessionLimit} htmlFor="sl">
@@ -73,17 +171,43 @@ export default function Settings({ api }: { api: StoreApi }) {
                 id="sl"
                 className="ctl"
                 type="number"
-                min={10}
-                max={300}
+                min={LIMITS.sessionLimit.min}
+                max={LIMITS.sessionLimit.max}
                 style={{ width: '100%' }}
-                value={store.settings.sessionLimit}
-                onChange={(e) => updateSettings({ sessionLimit: Number(e.target.value) })}
+                value={draft.sessionLimit}
+                onChange={(e) => editLimit('sessionLimit', e.target.value)}
+                onBlur={() => settle('sessionLimit')}
               />
             </Field>
           </div>
           <p className="tiny muted" style={sx({ marginTop: space[4], marginBottom: 0 })}>
             {study.clampNote}
           </p>
+          {/* Sits with the limits rather than in a section of its own (#38):
+              this is the fourth answer to "how much, and which part, does the
+              trainer put in front of me today?" and reads as a stranger
+              anywhere else. */}
+          <div
+            className="spread"
+            style={sx({
+              marginTop: space[6],
+              paddingTop: space[6],
+              borderTop: '1px solid var(--color-divider)',
+            })}
+          >
+            <div>
+              <strong className="small">{followPlan.heading}</strong>
+              <p className="tiny muted" style={sx({ margin: `${space[1]} 0 0`, maxWidth: '62ch' })}>
+                {followPlan.note}
+              </p>
+            </div>
+            <Segmented
+              ariaLabel={followPlan.label}
+              options={[...FOLLOW_PLAN_OPTIONS]}
+              value={store.settings.followPlan ? 'on' : 'off'}
+              onChange={(next) => updateSettings({ followPlan: next === 'on' })}
+            />
+          </div>
         </Card>
       </div>
 

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -34,7 +34,7 @@ const DIFFICULTY_OPTIONS = DIFFICULTIES.map((value) => ({
 
 /**
  * The follow-the-plan switch is a boolean, but it is rendered as the same
- * two-option Segmented the rest of this panel uses (#38) rather than a
+ * two-option Segmented the rest of this panel uses (#40) rather than a
  * checkbox: a checkbox states one side and leaves the other implied, and the
  * choice here is genuinely between two study strategies, not between a
  * behaviour and its absence.
@@ -45,7 +45,7 @@ const FOLLOW_PLAN_OPTIONS = [
 ] as const;
 
 /**
- * The bounds the two number fields already advertise through `min`/`max` (#38).
+ * The bounds the two number fields already advertise through `min`/`max` (#40).
  *
  * They live here rather than inline on the inputs alone because until now they
  * were decorative: a `min` attribute stops the spinner and the browser's own
@@ -62,7 +62,7 @@ const LIMITS = {
  * The value to commit for a limit field, or null for "do not commit anything".
  *
  * `Number('')` is 0 and `Number('-')` is NaN, and both used to go straight into
- * the store (#38). A committed `sessionLimit: 0` makes `buildQueue` return an
+ * the store (#40). A committed `sessionLimit: 0` makes `buildQueue` return an
  * empty array, so "Start review session" jumped to "Session complete — 0
  * answered"; and select-all-then-retype produces exactly that empty string as
  * an intermediate, so it took no misuse at all to hit it.
@@ -84,7 +84,7 @@ function limitToCommit(raw: string, bounds: { min: number; max: number }): numbe
  * — the one place this app deliberately departs from SM-2, guaranteeing every
  * card is seen at least once more before the quiz — simply stops applying, and
  * cards start scheduling past the exam date never to return. Nothing on screen
- * says so beyond a "NaN days until Invalid Date" in the header (#38).
+ * says so beyond a "NaN days until Invalid Date" in the header (#40).
  */
 function isUsableExamDate(raw: string): boolean {
   return raw !== '' && Number.isFinite(new Date(`${raw}T23:59:59`).getTime());
@@ -97,7 +97,7 @@ export default function Settings({ api }: { api: StoreApi }) {
 
   /**
    * What the three inputs *show*, which is deliberately not the same thing as
-   * what the store holds (#38).
+   * what the store holds (#40).
    *
    * Clamping the rendered value instead would make the fields miserable to
    * edit: clear "60" to type "120" and a store-driven value snaps you back to
@@ -183,7 +183,7 @@ export default function Settings({ api }: { api: StoreApi }) {
           <p className="tiny muted" style={sx({ marginTop: space[4], marginBottom: 0 })}>
             {study.clampNote}
           </p>
-          {/* Sits with the limits rather than in a section of its own (#38):
+          {/* Sits with the limits rather than in a section of its own (#40):
               this is the fourth answer to "how much, and which part, does the
               trainer put in front of me today?" and reads as a stranger
               anywhere else. */}

--- a/tests/e2e/difficulty.spec.ts
+++ b/tests/e2e/difficulty.spec.ts
@@ -15,7 +15,21 @@
 import { expect, test } from '@playwright/test';
 import { BOOKS, BOOKS_BY_ID } from '../../src/data/books';
 import { allItems } from '../../src/lib/generate';
-import { openAs, readStore, expectBooted } from './harness';
+import { DIFFICULTY_SPEC } from '../../src/lib/difficulty';
+import { daysFromNow, ITEM, openAs, readStore, soloQueue, expectBooted } from './harness';
+
+/** Options naming a book on the other side of the seam. */
+function crossings2(
+  options: string[] | undefined,
+  ownTestament: string,
+  byName: Map<string, { testament: string }>,
+): number {
+  if (!options) return 0;
+  return options.filter((o) => {
+    const book = byName.get(o);
+    return book !== undefined && book.testament !== ownTestament;
+  }).length;
+}
 
 const BOOK_BY_NAME = new Map(BOOKS.map((b) => [b.name, b]));
 
@@ -87,6 +101,189 @@ test.describe('difficulty — option scoping', () => {
     // than four — which would invert hard mode rather than sharpen it.
     expect(thin.map((i) => i.id)).toEqual([]);
   });
+});
+
+/**
+ * #38 — the setting stopped being a distractor-swap and became an axis.
+ *
+ * Before it, two thirds of the bank carried no alternate option sets at all:
+ * every `people`, `places`, `relationships`, `book-order`, `numbers`,
+ * `timeline` and `summaries` question fell back to its medium set, and plenty
+ * of those pools were canon-wide. So `hard` quietly offered New Testament
+ * options against Old Testament questions — 637 of them, measured — which is
+ * the complaint that started this. The tests below are the floor that stops
+ * that regressing.
+ */
+test.describe('difficulty — scoping across the whole bank', () => {
+  const mcq = allItems().filter((i) => i.kind === 'mcq');
+  const BY_NAME = new Map(BOOKS.map((b) => [b.name, b]));
+
+  /**
+   * Topics whose options are book *names*, so a Testament can be read off them.
+   *
+   * People questions are excluded deliberately even though their options are
+   * strings: Luke, James, Job and Zechariah are each both a person and a book,
+   * so matching option text against the canon there measures the collision, not
+   * a seam crossing.
+   */
+  const BOOK_ANSWER_TOPICS = new Set(['chapters', 'events', 'summaries']);
+
+  test('hard never offers an option from the other Testament', () => {
+    let crossings = 0;
+    const offenders: string[] = [];
+
+    for (const item of mcq) {
+      if (!item.book || !BOOK_ANSWER_TOPICS.has(item.topic)) continue;
+      const own = BOOKS_BY_ID[item.book]?.testament;
+      if (!own) continue;
+      const c = crossings2(item.distractorsBy?.hard, own, BY_NAME);
+      crossings += c;
+      if (c && offenders.length < 5) offenders.push(`${item.id} | ${item.prompt}`);
+    }
+
+    expect(crossings, `hard crossings, e.g. ${offenders.join(' ; ')}`).toBe(0);
+  });
+
+  /**
+   * Book Order is the one family where the Testament seam is the wrong fence:
+   * "which book immediately follows Malachi?" has a New Testament answer to an
+   * Old Testament question, so scoping by Testament would identify the answer
+   * without knowing the canon at all. What makes it hard is *canonical
+   * distance* — Ezra against Nehemiah, Esther and Chronicles is a question;
+   * Ezra against Matthew is a free point.
+   */
+  test('book-order draws hard options from canonical neighbours, and easy ones from far away', () => {
+    const bookOrder = mcq.filter((i) => i.topic === 'book-order' && i.book);
+    expect(bookOrder.length).toBeGreaterThan(0);
+
+    let farOnHard = 0;
+    let nearOnEasy = 0;
+    for (const item of bookOrder) {
+      const subject = BOOKS_BY_ID[item.book!];
+      if (!subject) continue;
+      for (const o of item.distractorsBy?.hard ?? []) {
+        const b = BY_NAME.get(o);
+        if (b && Math.abs(b.order - subject.order) > 8) farOnHard++;
+      }
+      for (const o of item.distractorsBy?.easy ?? []) {
+        const b = BY_NAME.get(o);
+        if (b && Math.abs(b.order - subject.order) <= 4) nearOnEasy++;
+      }
+    }
+
+    expect(farOnHard, 'a hard book-order option more than 8 positions away').toBe(0);
+    expect(nearOnEasy, 'an easy book-order option among the answer’s neighbours').toBe(0);
+  });
+
+  /**
+   * `pickDistractors` excludes the answer but never knew about the *subject*,
+   * so "Which book immediately precedes Leviticus?" offered Leviticus — an
+   * option that is wrong for a reason the question itself gives away.
+   */
+  test('no question offers the book it is asking about', () => {
+    const offenders: string[] = [];
+    for (const item of mcq) {
+      if (item.topic !== 'book-order' || !item.book) continue;
+      const subject = BOOKS_BY_ID[item.book]?.name;
+      if (!subject) continue;
+      const every = [
+        ...(item.distractors ?? []),
+        ...(item.distractorsBy?.easy ?? []),
+        ...(item.distractorsBy?.hard ?? []),
+      ];
+      if (every.includes(subject)) offenders.push(item.id);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test('almost every question carries all three option sets', () => {
+    const withHard = mcq.filter((i) => i.distractorsBy?.hard).length;
+    // A floor, not an equality: the handful of hand-authored items in
+    // src/data/extras.ts draw their options from somewhere other than the
+    // canon and legitimately have none. Before #38 this was 4,554 of 5,926.
+    expect(withHard / mcq.length).toBeGreaterThan(0.99);
+  });
+
+  test('hard is never thinner than medium, which would invert the setting', () => {
+    const thin = mcq.filter(
+      (i) => i.distractorsBy?.hard && i.distractorsBy.hard.length < (i.distractors ?? []).length,
+    );
+    expect(thin.map((i) => i.id)).toEqual([]);
+  });
+
+  test('hard offers more choices than medium, and easy fewer', () => {
+    const rendered = (item: (typeof mcq)[number], d: 'easy' | 'medium' | 'hard') => {
+      const pool = d === 'medium'
+        ? item.distractors ?? []
+        : item.distractorsBy?.[d] ?? item.distractors ?? [];
+      return Math.min(pool.length, DIFFICULTY_SPEC[d].wrongOptions) + 1;
+    };
+    // The dial that costs nothing in item stability and is felt on every card:
+    // a three-option question is a coin flip after one elimination.
+    expect(mcq.every((i) => rendered(i, 'easy') === 3)).toBe(true);
+    expect(mcq.every((i) => rendered(i, 'medium') === 4)).toBe(true);
+    expect(mcq.filter((i) => rendered(i, 'hard') === 6).length / mcq.length).toBeGreaterThan(0.99);
+  });
+
+  test('no alternate set contains the answer it is meant to be wrong about', () => {
+    const leaks = mcq.filter(
+      (i) => (i.distractorsBy?.easy ?? []).includes(i.answer)
+        || (i.distractorsBy?.hard ?? []).includes(i.answer),
+    );
+    expect(leaks.map((i) => i.id)).toEqual([]);
+  });
+});
+
+/**
+ * The dial a member actually feels, card by card (#38).
+ *
+ * Option scoping is invisible unless you already know the canon; option *count*
+ * is not. Three choices is a coin flip after one elimination, six is a real
+ * question, and neither costs anything in item stability — the bank stays
+ * difficulty-blind and the render site slices.
+ */
+test.describe('difficulty — what reaches the card', () => {
+  const CHOICES = { easy: 3, medium: 4, hard: 6 } as const;
+
+  for (const [difficulty, expected] of Object.entries(CHOICES)) {
+    test(`${difficulty} puts ${expected} choices on the card`, async ({ page }) => {
+      await openAs(page, { store: { ...soloQueue(ITEM.mcq), settings: {
+        examDate: daysFromNow(60), newLimit: 0, sessionLimit: 1, difficulty,
+      } } }, 'review');
+      await page.getByRole('button', { name: 'Start review session' }).click();
+
+      await expect(page.getByText('Which book immediately follows Genesis?')).toBeVisible();
+      await expect(page.locator('.choice')).toHaveCount(expected);
+    });
+  }
+
+  /**
+   * A reference question opens with a chance to name it from memory before any
+   * options appear (#14). Naming is strictly harder than recognising, so easy
+   * skips the prompt and goes straight to recognition; medium and hard ask.
+   *
+   * `gen-locate-joshua-6` is a `gen-locate` item, so its answer is a reference.
+   */
+  const REF_ITEM = 'gen-locate-joshua-6';
+  const refSeed = (difficulty: string) => ({
+    ...soloQueue(REF_ITEM),
+    settings: { examDate: daysFromNow(60), newLimit: 0, sessionLimit: 1, difficulty },
+  });
+
+  test('easy shows the options straight away', async ({ page }) => {
+    await openAs(page, { store: refSeed('easy') }, 'review');
+    await page.getByRole('button', { name: 'Start review session' }).click();
+
+    await expect(page.locator('.choice')).toHaveCount(3);
+  });
+
+  test('medium asks for the reference before showing any options', async ({ page }) => {
+    await openAs(page, { store: refSeed('medium') }, 'review');
+    await page.getByRole('button', { name: 'Start review session' }).click();
+
+    await expect(page.locator('.choice')).toHaveCount(0);
+  });
+
 });
 
 test.describe('difficulty — the control', () => {

--- a/tests/e2e/difficulty.spec.ts
+++ b/tests/e2e/difficulty.spec.ts
@@ -14,7 +14,8 @@
  */
 import { expect, test } from '@playwright/test';
 import { BOOKS, BOOKS_BY_ID } from '../../src/data/books';
-import { allItems } from '../../src/lib/generate';
+import { allItems, ITEMS_BY_ID } from '../../src/lib/generate';
+import { buildQueue, type ItemMeta } from '../../src/lib/srs';
 import { DIFFICULTY_SPEC } from '../../src/lib/difficulty';
 import { daysFromNow, ITEM, openAs, readStore, soloQueue, expectBooted } from './harness';
 
@@ -242,6 +243,84 @@ test.describe('difficulty — scoping across the whole bank', () => {
  * question, and neither costs anything in item stability — the bank stays
  * difficulty-blind and the render site slices.
  */
+/**
+ * Which new cards get introduced, and whether you can predict them (#38).
+ *
+ * The complaint: "build the frame is great in going through all of the books
+ * but it's in order — for easy mode that's fine but for hard mode it should
+ * not be. It's too easy to predict." It was literally true at every setting.
+ * `fresh` arrives in the bank's generation order, which is canonical, and
+ * `buildQueue` took `fresh.slice(0, newLimit)`. The within-session shuffle
+ * (#11) never touched it, because it only reorders cards already chosen.
+ */
+test.describe('difficulty — how new material is introduced', () => {
+  const items = allItems();
+  const meta: Record<string, ItemMeta> = {};
+  for (const i of items) meta[i.id] = { tier: i.tier, book: i.book };
+
+  const introduced = (difficulty: 'easy' | 'medium' | 'hard', seed: string) =>
+    new Set(buildQueue(items.map((i) => i.id), {}, {
+      newLimit: 10, sessionLimit: 10, difficulty, meta, seed,
+    }));
+
+  const bookSpan = (ids: Set<string>) => {
+    const orders = [...ids]
+      .map((id) => BOOKS_BY_ID[ITEMS_BY_ID.get(id)!.book ?? '']?.order)
+      .filter((n): n is number => typeof n === 'number');
+    return orders.length ? Math.max(...orders) - Math.min(...orders) : 0;
+  };
+
+  test('easy walks the canon from the beginning', () => {
+    const first = introduced('easy', '2026-08-22');
+    const orders = [...first]
+      .map((id) => BOOKS_BY_ID[ITEMS_BY_ID.get(id)!.book ?? '']?.order)
+      .filter((n): n is number => typeof n === 'number');
+
+    // Genesis-first, and tightly clustered — the frame is built front to back.
+    // This is also why the tier bias is not allowed to reorder `canonical`:
+    // floating tier 1 forward opened easy on Isaiah instead of Genesis.
+    expect(Math.min(...orders)).toBe(1);
+    expect(bookSpan(first)).toBeLessThan(10);
+  });
+
+  test('hard draws from across the whole scope instead', () => {
+    expect(bookSpan(introduced('hard', '2026-08-22'))).toBeGreaterThan(20);
+  });
+
+  test('hard deals a different hand each day, where easy deals the same one', () => {
+    const easyToday = introduced('easy', '2026-08-22');
+    const easyTomorrow = introduced('easy', '2026-08-23');
+    const hardToday = introduced('hard', '2026-08-22');
+    const hardTomorrow = introduced('hard', '2026-08-23');
+
+    const overlap = (a: Set<string>, b: Set<string>) => [...a].filter((x) => b.has(x)).length;
+
+    // Easy is deliberately predictable: the same next cards until you clear them.
+    expect(overlap(easyToday, easyTomorrow)).toBe(easyToday.size);
+    // Hard is not. This is the whole complaint, inverted into a guarantee.
+    expect(overlap(hardToday, hardTomorrow)).toBeLessThan(hardToday.size / 2);
+  });
+
+  test('a reload does not deal a different hand mid-session', () => {
+    // Seeded, not Math.random(): unpredictable across days, fixed within one.
+    const a = introduced('hard', '2026-08-22');
+    const b = introduced('hard', '2026-08-22');
+    expect([...a].sort()).toEqual([...b].sort());
+  });
+
+  test('hard introduces more new cards than medium, and easy fewer', () => {
+    // A session limit well above the new-card limit, or the cut hides the
+    // difference this is measuring.
+    const count = (difficulty: 'easy' | 'medium' | 'hard') =>
+      buildQueue(items.map((i) => i.id), {}, {
+        newLimit: 10, sessionLimit: 500, difficulty, meta, seed: 's',
+      }).length;
+
+    expect(count('hard')).toBeGreaterThan(count('medium'));
+    expect(count('easy')).toBeLessThan(count('medium'));
+  });
+});
+
 test.describe('difficulty — what reaches the card', () => {
   const CHOICES = { easy: 3, medium: 4, hard: 6 } as const;
 

--- a/tests/e2e/difficulty.spec.ts
+++ b/tests/e2e/difficulty.spec.ts
@@ -105,7 +105,7 @@ test.describe('difficulty — option scoping', () => {
 });
 
 /**
- * #38 — the setting stopped being a distractor-swap and became an axis.
+ * #40 — the setting stopped being a distractor-swap and became an axis.
  *
  * Before it, two thirds of the bank carried no alternate option sets at all:
  * every `people`, `places`, `relationships`, `book-order`, `numbers`,
@@ -201,7 +201,7 @@ test.describe('difficulty — scoping across the whole bank', () => {
     const withHard = mcq.filter((i) => i.distractorsBy?.hard).length;
     // A floor, not an equality: the handful of hand-authored items in
     // src/data/extras.ts draw their options from somewhere other than the
-    // canon and legitimately have none. Before #38 this was 4,554 of 5,926.
+    // canon and legitimately have none. Before #40 this was 4,554 of 5,926.
     expect(withHard / mcq.length).toBeGreaterThan(0.99);
   });
 
@@ -236,7 +236,7 @@ test.describe('difficulty — scoping across the whole bank', () => {
 });
 
 /**
- * The dial a member actually feels, card by card (#38).
+ * The dial a member actually feels, card by card (#40).
  *
  * Option scoping is invisible unless you already know the canon; option *count*
  * is not. Three choices is a coin flip after one elimination, six is a real
@@ -244,7 +244,7 @@ test.describe('difficulty — scoping across the whole bank', () => {
  * difficulty-blind and the render site slices.
  */
 /**
- * Which new cards get introduced, and whether you can predict them (#38).
+ * Which new cards get introduced, and whether you can predict them (#40).
  *
  * The complaint: "build the frame is great in going through all of the books
  * but it's in order — for easy mode that's fine but for hard mode it should

--- a/tests/e2e/plan.spec.ts
+++ b/tests/e2e/plan.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * The study plan drives what you study (#38).
+ *
+ * The plan has always been *displayed* — Plan.tsx renders the schedule and the
+ * Dashboard names the current phase — but nothing filtered the queue by it, so
+ * following it was left entirely to the member's own discipline. These tests
+ * pin the two halves of making it real: the daily review draws from the phase,
+ * and the phase actually advances as the weeks pass.
+ *
+ * That second half is the one worth guarding hardest. `buildSchedule` defaults
+ * its start date to `new Date()`, so a schedule built today always puts today
+ * in week 1 — which meant `currentPhase` answered "Phase 1" forever. Harmless
+ * while the plan was decorative; the moment it gates the queue it would have
+ * pinned every member to book-order and summaries, 330 of 6,098 items, until
+ * the exam date passed. The anchor is a persisted plan start instead.
+ */
+import { expect, test } from '@playwright/test';
+import { DAY, ITEM, daysFromNow, dueCard, openAs, readStore } from './harness';
+
+/** An ISO date `n` days back, for seeding a plan that started in the past. */
+function daysAgo(n: number): string {
+  return daysFromNow(-n);
+}
+
+test.describe('following the study plan', () => {
+  /**
+   * `ITEM.mcq` is `book-order`, which Phase 1 asks for; `ITEM.type` is
+   * `numbers` and `ITEM.order` is `events`, which it does not.
+   */
+  const straddling = {
+    [ITEM.mcq]: dueCard(ITEM.mcq),
+    [ITEM.type]: dueCard(ITEM.type),
+    [ITEM.order]: dueCard(ITEM.order),
+  };
+
+  const settings = (over = {}) => ({
+    examDate: daysFromNow(60),
+    newLimit: 0,
+    sessionLimit: 60,
+    ...over,
+  });
+
+  test('the review session only asks what the current phase covers', async ({ page }) => {
+    await openAs(page, { store: { cards: straddling, settings: settings({ followPlan: true }) } }, 'review');
+
+    await expect(page.getByText(/Following the study plan/)).toBeVisible();
+    await page.getByRole('button', { name: 'Start review session' }).click();
+
+    // One card, and it is the book-order one — not the numbers or events cards.
+    await expect(page.getByRole('progressbar', { name: '0 of 1 answered' })).toBeVisible();
+    await expect(page.getByText('Which book immediately follows Genesis?')).toBeVisible();
+  });
+
+  test('you can set the plan aside for one session without changing the setting', async ({ page }) => {
+    await openAs(page, { store: { cards: straddling, settings: settings({ followPlan: true }) } }, 'review');
+
+    // One click from the same screen: it starts the session outright rather
+    // than returning to the idle screen with a different setting selected.
+    await page.getByRole('button', { name: 'Study everything instead' }).click();
+
+    await expect(page.getByRole('progressbar', { name: '0 of 3 answered' })).toBeVisible();
+    // Setting aside is a session-level choice; the saved preference is untouched.
+    expect((await readStore(page)).settings.followPlan).toBe(true);
+  });
+
+  test('turning the setting off leaves the queue drawing on the whole bank', async ({ page }) => {
+    await openAs(page, { store: { cards: straddling, settings: settings({ followPlan: false }) } }, 'review');
+
+    await expect(page.getByText(/Following the study plan/)).toHaveCount(0);
+    await page.getByRole('button', { name: 'Start review session' }).click();
+    await expect(page.getByRole('progressbar', { name: '0 of 3 answered' })).toBeVisible();
+  });
+
+  test('the setting is saved and survives a reload', async ({ page }) => {
+    await openAs(page, {}, 'settings');
+
+    await page.getByRole('radio', { name: 'Off' }).click();
+    expect((await readStore(page)).settings.followPlan).toBe(false);
+
+    await page.reload();
+    await expect(page.getByRole('radio', { name: 'Off' })).toBeChecked();
+  });
+
+  test('an account saved before the setting existed follows the plan by default', async ({ page }) => {
+    // The key postdates the store format, so a store written before #38 has no
+    // such field. It must read as on — the plan is the app's whole premise —
+    // rather than leaving the control with nothing selected.
+    await openAs(page, {}, 'settings');
+    await expect(page.getByRole('radio', { name: 'On' })).toBeChecked();
+  });
+
+  test('the plan advances as the weeks pass rather than resetting to phase one', async ({ page }) => {
+    // A member eight weeks into a plan with the exam four weeks out is well
+    // past building the frame. Anchoring on `new Date()` answered "Phase 1"
+    // here, which is the bug this guards.
+    await openAs(page, {
+      store: {
+        settings: { examDate: daysFromNow(28), newLimit: 0, sessionLimit: 60, planStart: daysAgo(56) },
+        log: [{ date: daysAgo(56), reviewed: 1, correct: 1 }],
+      },
+    }, 'review');
+
+    await expect(page.getByText(/Following the study plan/)).toBeVisible();
+    await expect(page.getByText(/Following the study plan: Phase 1/)).toHaveCount(0);
+  });
+
+  test('a plan started today is still on phase one', async ({ page }) => {
+    await openAs(page, {
+      store: { settings: { examDate: daysFromNow(60), newLimit: 0, sessionLimit: 60, planStart: daysFromNow(0) } },
+    }, 'review');
+
+    await expect(page.getByText(/Following the study plan: Phase 1/)).toBeVisible();
+  });
+});
+
+test.describe('the quiz can be pointed at the plan', () => {
+  test('this week’s plan is offered as a scope and narrows the pool', async ({ page }) => {
+    await openAs(page, {}, 'quiz');
+
+    const count = async () => {
+      const text = await page.getByText(/questions? match this filter/).textContent();
+      return Number(/(\d+)/.exec(text ?? '')?.[1] ?? 0);
+    };
+
+    await page.getByRole('radio', { name: 'Everything' }).click();
+    const everything = await count();
+
+    await page.getByRole('radio', { name: 'This week’s plan' }).click();
+    const planned = await count();
+
+    expect(planned).toBeGreaterThan(0);
+    expect(planned).toBeLessThan(everything);
+  });
+});

--- a/tests/e2e/plan.spec.ts
+++ b/tests/e2e/plan.spec.ts
@@ -1,5 +1,5 @@
 /**
- * The study plan drives what you study (#38).
+ * The study plan drives what you study (#40).
  *
  * The plan has always been *displayed* — Plan.tsx renders the schedule and the
  * Dashboard names the current phase — but nothing filtered the queue by it, so
@@ -82,7 +82,7 @@ test.describe('following the study plan', () => {
   });
 
   test('an account saved before the setting existed follows the plan by default', async ({ page }) => {
-    // The key postdates the store format, so a store written before #38 has no
+    // The key postdates the store format, so a store written before #40 has no
     // such field. It must read as on — the plan is the app's whole premise —
     // rather than leaving the control with nothing selected.
     await openAs(page, {}, 'settings');

--- a/tests/e2e/review.spec.ts
+++ b/tests/e2e/review.spec.ts
@@ -10,7 +10,7 @@ async function answerMcq(page: Page, label: string) {
 
 test.describe('daily review', () => {
   /**
-   * The three seeded cards straddle the plan's first phase on purpose (#38).
+   * The three seeded cards straddle the plan's first phase on purpose (#40).
    *
    * `ITEM.mcq` is a `book-order` question, which Phase 1 — Build the Frame —
    * asks for. `ITEM.type` is `numbers` and `ITEM.order` is `events`, neither of
@@ -74,7 +74,7 @@ test.describe('daily review', () => {
   });
 
   test('a missed card is requeued and asked again', async ({ page }) => {
-    // Fixed in #38 by keying the session card on the queue position rather than
+    // Fixed in #40 by keying the session card on the queue position rather than
     // `item.id`. When a missed card was requeued as the *very next* card — which
     // is what happens whenever you miss the last card of a session — React
     // reused the component, QuestionCard's reset effect (keyed on the same
@@ -119,7 +119,7 @@ test.describe('daily review', () => {
   test('the running tally updates as the session goes', async ({ page }) => {
     const cards = { [ITEM.mcq]: dueCard(ITEM.mcq), [ITEM.type]: dueCard(ITEM.type) };
     // The plan is off here so the tally is tested on its own terms: the two
-    // seeded cards sit in different phases (#38), and this test is about the
+    // seeded cards sit in different phases (#40), and this test is about the
     // counter, not about which cards the plan admits.
     await openAs(page, { store: { cards, settings: { examDate: daysFromNow(60), newLimit: 0, sessionLimit: 2, followPlan: false } } }, 'review');
     await start(page);

--- a/tests/e2e/review.spec.ts
+++ b/tests/e2e/review.spec.ts
@@ -42,18 +42,15 @@ test.describe('daily review', () => {
     expect(store.log.at(-1)).toMatchObject({ reviewed: 1, correct: 1 });
   });
 
-  test('a missed card is requeued and asked again — currently it comes back pre-answered', async ({ page }) => {
-    // KNOWN BUG (src/views/Review.tsx:127): the session card is keyed on
-    // `item.id`, so when a missed card is requeued as the *very next* card —
-    // which is what happens whenever you miss the last card of a session —
-    // React reuses the component and QuestionCard's reset effect, keyed on the
-    // same `item.id`, never fires. The card returns still revealed, with the
-    // wrong answer in a disabled input: no retrieval, which is the entire point
-    // of requeueing it. Keying on the queue position instead fixes it.
-    // Delete this `test.fail()` once it is fixed — Playwright will flag the
-    // test as unexpectedly passing.
-    test.fail();
-
+  test('a missed card is requeued and asked again', async ({ page }) => {
+    // Fixed in #38 by keying the session card on the queue position rather than
+    // `item.id`. When a missed card was requeued as the *very next* card — which
+    // is what happens whenever you miss the last card of a session — React
+    // reused the component, QuestionCard's reset effect (keyed on the same
+    // `item.id`) never fired, and the card returned still revealed. There was no
+    // retrieval, which is the entire point of requeueing it; worse, the only way
+    // forward was Continue, which graded the same miss again. One miss recorded
+    // three reps and three lapses, one short of the leech threshold.
     await openAs(page, { store: soloQueue(ITEM.mcq) }, 'review');
     await start(page);
 
@@ -73,8 +70,7 @@ test.describe('daily review', () => {
     // Miss it three times; the third must not extend the session again.
     for (let attempt = 1; attempt <= 3; attempt++) {
       await expect(page.getByText('Which book immediately follows Genesis?')).toBeVisible();
-      // Tolerates the requeue bug above: only answer if the card is still open.
-      if (await page.locator('.feedback').count() === 0) await answerMcq(page, 'Deuteronomy');
+      await answerMcq(page, 'Deuteronomy');
       await page.getByRole('button', { name: /^Continue/ }).click();
     }
 

--- a/tests/e2e/review.spec.ts
+++ b/tests/e2e/review.spec.ts
@@ -9,14 +9,45 @@ async function answerMcq(page: Page, label: string) {
 }
 
 test.describe('daily review', () => {
-  test('the idle screen counts what is due, what is new, and what has been seen', async ({ page }) => {
-    const cards = {
-      [ITEM.mcq]: dueCard(ITEM.mcq),
-      [ITEM.type]: dueCard(ITEM.type),
-      // Not due for a week — should count as seen but not as due.
-      [ITEM.order]: dueCard(ITEM.order, { due: Date.now() + 7 * DAY }),
-    };
-    await openAs(page, { store: { cards, settings: { examDate: daysFromNow(60), newLimit: 5, sessionLimit: 60 } } }, 'review');
+  /**
+   * The three seeded cards straddle the plan's first phase on purpose (#38).
+   *
+   * `ITEM.mcq` is a `book-order` question, which Phase 1 — Build the Frame —
+   * asks for. `ITEM.type` is `numbers` and `ITEM.order` is `events`, neither of
+   * which it does. So the same store reads two different, both-correct ways
+   * depending on whether the plan is being followed, and the pair of tests
+   * below pins each. Counting inside the scope is the honest number: the idle
+   * screen promises a quantity of due cards and then hands over a session, so
+   * if those two disagree the promise is a lie.
+   */
+  const straddlingPlan = {
+    [ITEM.mcq]: dueCard(ITEM.mcq),
+    [ITEM.type]: dueCard(ITEM.type),
+    // Not due for a week — should count as seen but not as due.
+    [ITEM.order]: dueCard(ITEM.order, { due: Date.now() + 7 * DAY }),
+  };
+
+  test('the idle screen counts inside the phase the plan is asking for', async ({ page }) => {
+    await openAs(page, {
+      store: {
+        cards: straddlingPlan,
+        settings: { examDate: daysFromNow(60), newLimit: 5, sessionLimit: 60, followPlan: true },
+      },
+    }, 'review');
+
+    // Only the book-order card is in Phase 1, so it is the only one counted.
+    await expectStat(page, 'Due now', 1);
+    await expectStat(page, 'New today', 5); // capped by the new-card limit
+    await expectStat(page, 'Seen so far', 1);
+  });
+
+  test('turning the plan off counts what is due, what is new, and what has been seen', async ({ page }) => {
+    await openAs(page, {
+      store: {
+        cards: straddlingPlan,
+        settings: { examDate: daysFromNow(60), newLimit: 5, sessionLimit: 60, followPlan: false },
+      },
+    }, 'review');
 
     await expectStat(page, 'Due now', 2);
     await expectStat(page, 'New today', 5); // capped by the new-card limit
@@ -87,7 +118,10 @@ test.describe('daily review', () => {
 
   test('the running tally updates as the session goes', async ({ page }) => {
     const cards = { [ITEM.mcq]: dueCard(ITEM.mcq), [ITEM.type]: dueCard(ITEM.type) };
-    await openAs(page, { store: { cards, settings: { examDate: daysFromNow(60), newLimit: 0, sessionLimit: 2 } } }, 'review');
+    // The plan is off here so the tally is tested on its own terms: the two
+    // seeded cards sit in different phases (#38), and this test is about the
+    // counter, not about which cards the plan admits.
+    await openAs(page, { store: { cards, settings: { examDate: daysFromNow(60), newLimit: 0, sessionLimit: 2, followPlan: false } } }, 'review');
     await start(page);
 
     await expect(page.getByText('0 right · 0 missed')).toBeVisible();


### PR DESCRIPTION
Three complaints, traced to three mechanisms, plus the defects found on the way.

> "Even though I set the difficulty to hard, I still get NT and OT answer choices even though it's supposed to be within the same book only. I think the difficulty system is not best made. Can you make sure that the scripture mastery actually follows the study plan? Build the frame is great in going through all of the books but it's in order — for easy mode that's fine but for hard mode it should not be in order, it's too easy to predict."

## ⚠️ One behaviour change for existing members

**`followPlan` defaults to on**, so everyone's daily review starts drawing from their current phase instead of the whole bank. Two escape hatches, both one click: **Study everything instead** on the review screen sets it aside for a single session, and **Settings → Follow the study plan → Off** turns it off for good. Sessions also widen automatically when a phase runs dry, so it can never say "nothing to study".

## Why hard was still offering the wrong Testament

Not a broken seam rule — a barely-applied one. Only **2,971 of 6,098** items carried a hard option set. Every People, Places, Family, Book Order, Numbers, Timeline and Book Summaries question had none, so `QuestionCard` fell back to the medium set, and many of those pools were canon-wide.

| | before | after |
|---|--:|--:|
| mcq items with a hard option set | 4,554 / 5,926 | **5,915 / 5,926** |
| hard options from the other Testament | **637** | **0** |
| hard sets thinner than medium (which would *invert* the setting) | — | 0 |

The remaining 11 are hand-written items in `src/data/extras.ts` that draw options from outside the canon.

**Book Order is deliberately exempt from the seam rule.** "Which book immediately follows Malachi?" has a New Testament answer, so fencing it by Testament identifies the answer without knowing the canon. It is scoped by *canonical distance* instead — neighbours within 4 positions on hard, a dozen away on easy.

## The setting now changes four things, not one

The bank stays difficulty-blind — item ids key SRS history, so nothing regenerates and no review history detaches. Difficulty lives entirely in what reaches the card and which cards reach you.

| | Easy | Medium | Hard |
|---|---|---|---|
| Options offered | 3 | 4 | **6** |
| Wrong options from | anywhere in the canon | nearby books, never across the seam | as close as the question allows |
| Reference answers | shown as choices | named from memory first | named from memory first, no hint |
| Hint before answering | yes | no | no |
| New material | walks the canon in order | interleaved | anywhere in scope, unpredictable, 1.5× |
| A card you miss | back this session | back this session | back tomorrow |

## Why "Build the Frame" was predictable

It was literally true at every setting. Unseen cards arrive in generation order, which is canonical, and `buildQueue` took `fresh.slice(0, newLimit)`. The within-session shuffle (#11) never touched it — it only reorders cards already chosen.

Measured over Phase 1's 330 items, 10 new cards a day:

| | books spanned | still there tomorrow |
|---|---|---|
| easy | 1–4 (**span 3**) | 6 / 6 — a stable canonical march |
| medium | 1–6 (span 5) | 10 / 10 |
| hard | 11–38 (**span 27**) | **2 / 10** |

The draw is seeded per day, not random, so a reload does not deal a new hand mid-session. Easy's canonical march is explicitly protected from the tier bias — floating tier 1 forward opened easy on *Isaiah* instead of Genesis, which is not what building a frame means.

## The plan now drives the daily review

The five phases were rendered but nothing filtered by them. Now the daily review draws from the current phase, the Quiz offers **This week's plan** as a scope, and the review screen names the phase up front rather than letting you discover a short session and read it as a bug.

Making it real exposed why it had been safe to leave decorative: **`buildSchedule` anchored its start to `new Date()` on every call**, so today was always inside week 1 and the current phase was always Phase 1. Harmless while nothing consumed it — it is why the Dashboard always read "Week 1" — but as a filter it would have pinned every member to Book Order and Book Summaries, **330 of 6,098 questions**, until the exam date passed. The schedule now anchors to a persisted plan start, derived from your earliest recorded session so a returning member is not sent back to the beginning.

## Defects found and fixed on the way

- **Missing the last card of a session graded it three times.** A requeued card landing at the same position kept the same React key, so the card was never remounted and came back *already answered*; the only way forward was Continue, which graded the same miss again. One miss recorded 3 reviews and **3 lapses** — one short of the leech threshold — and skewed Progress accuracy. `review.spec.ts` had this documented as a `test.fail()` KNOWN BUG; that test now asserts the fixed behaviour.
- **Clearing the quiz date silently disabled the exam clamp.** It committed `''`, `examTimeOf` returned `NaN`, and `NaN > 0` being false meant the interval clamp — the one deliberate deviation from SM-2 — stopped applying, letting cards schedule past the exam. Clearing a number field committed `0`, so a moment's editing of *Max cards per session* could send "Start review session" straight to a finished session.
- **Six questions offered the book they were asking about** — "Which book immediately precedes Leviticus?" listed Leviticus. Distractor selection excluded the *answer* but was never told about the subject.
- **A wrong option could be a second correct answer.** Event questions excluded participants from their options, but only from the medium pool; tightening hard to the same book would have started offering genuine participants. No content check can catch this — they compare options against *the* answer.
- **Accessibility**: no `<h1>`, no focus move on tab change, order rows signalling correctness by colour alone, ordering buttons dropping focus at the list ends, and the Correct/Not quite verdict never announced.
- **Export** could silently no-op in Firefox and Safari.

## Byte-identity

Medium option sets are unchanged for **6,092 of 6,098** items, verified by full-bank snapshot diff at every step. The 6 exceptions are exactly the self-distractor fix: `gen-prev-leviticus`, `gen-position-psalms`, `gen-prev-psalms`, `gen-position-habakkuk`, `gen-position-haggai`, `gen-prev-zechariah`.

## Testing

**150 passing, up from 123.** 27 new tests covering the seam rule across the whole bank, canonical-distance scoping for book order, the subject-book fix, rendered option counts per setting, the bonus-round policy, how new cards are introduced and whether tomorrow is predictable, plan-scoped sessions, the top-up, and phase advancement. `npm run check`, `npm run validate` and `npm run build` all clean. Verified live in the browser at each setting.

## Deliberately deferred — not fixed here

- **Firestore writes will silently lose data.** `useStore.commit` calls `setDoc` without `{ merge: true }`, rewriting the whole store on every grade (~660 KB per write at 3,000 cards; ~40 MB per 60-card session). Projected to cross the **1 MiB document limit at ~4,515 cards seen** against a 6,098-item bank — past which every write fails `INVALID_ARGUMENT`, is swallowed by a bare `console.error`, and **all further progress is lost until reload**. Needs per-card writes and surfaced failures; its own PR.
- **122 questions contain their own answer in the prompt** — *"In which book do we primarily read about Joshua?"* → Joshua. Needs rewording plus a `validate.ts` gate.
- **~1,402 items' `explain` restates the answer** rather than explaining it. Contained here by suppressing the easy-mode hint whenever it would give the answer away, but the underlying content is unchanged.
- **23 pre-existing medium seam crossings** on `det-distinctive-*`, left alone to preserve byte-identity. Hard is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
