### PR TITLE
Let the plan ration new material without withholding due cards

### DIFF
--- a/src/lib/plan-scope.ts
+++ b/src/lib/plan-scope.ts
@@ -57,12 +57,16 @@ export function planScopeIds(phase: Phase, items: readonly Item[]): Set<string> 
  */
 export function withTopUp(scoped: string[], all: string[], want: number): string[] {
   if (scoped.length >= want) return scoped;
+  // Widen to *everything* rather than to exactly `want`.
+  //
+  // Stopping at `want` capped the candidate pool at the session limit, taken as
+  // a plain prefix of the bank — which is canonical order. Every later stage
+  // that decides what a session contains, the due-date sort and the hard-mode
+  // shuffle alike, then ran inside a Genesis-first slice of sixty. For a member
+  // with a real backlog that meant the most overdue cards were never even
+  // candidates: the queue was choosing from the front of the canon and calling
+  // it urgency. `want` now decides only *whether* to widen, never how far, and
+  // buildQueue does the cut on its own terms (#41).
   const have = new Set(scoped);
-  const out = [...scoped];
-  for (const id of all) {
-    if (out.length >= want) break;
-    if (have.has(id)) continue;
-    out.push(id);
-  }
-  return out;
+  return [...scoped, ...all.filter((id) => !have.has(id))];
 }

--- a/src/lib/srs.ts
+++ b/src/lib/srs.ts
@@ -196,7 +196,9 @@ export function buildQueue(
   // start recalling the sequence rather than the answer (#11). Note this is
   // the presentation shuffle, not #40's: it reorders one session's cards after
   // the cut, and cannot change which cards were introduced in the first place.
-  return shuffle(interleave(picked).slice(0, opts.sessionLimit));
+  // Cut by urgency first, then spread. Interleaving before the cut let the
+  // round-robin decide which cards survived it (#41).
+  return shuffle(interleave(picked.slice(0, opts.sessionLimit), opts.meta));
 }
 
 /**
@@ -262,10 +264,10 @@ function tierOf(id: string, meta: Record<string, ItemMeta>): number {
   return meta[id]?.tier ?? 2;
 }
 
-function bookOf(id: string, meta: Record<string, ItemMeta>): string {
+function bookOf(id: string, meta?: Record<string, ItemMeta>): string {
   // Same fallback key `interleave` uses, so an item missing a book still gets
   // grouped the way the rest of the queue groups it.
-  return meta[id]?.book ?? id.split('-').slice(0, 2).join('-');
+  return meta?.[id]?.book ?? id.split('-').slice(0, 2).join('-');
 }
 
 /**
@@ -297,10 +299,18 @@ function spreadByBook(ids: string[], meta: Record<string, ItemMeta>): string[] {
 }
 
 /** Spread same-prefix items apart so you are not answering six Genesis cards in a row. */
-function interleave(ids: string[]): string[] {
+function interleave(ids: string[], meta?: Record<string, ItemMeta>): string[] {
   const buckets = new Map<string, string[]>();
   for (const id of ids) {
-    const key = id.split('-').slice(0, 2).join('-');
+    // Bucket by book. The id prefix looks like a book key and is not one: it
+    // yields families such as `gen-position` and `det-ev`, each spanning the
+    // whole canon, so nearly the entire bank lands in a handful of buckets that
+    // are all "every book". Round-robin across those does not spread books at
+    // all — and because the session cut happens after this, it also decides
+    // *which* cards survive: a bucket holding two due cards got the same share
+    // as one holding nine hundred, so the most overdue cards were routinely
+    // cut. Falls back to the old key only when meta is absent (#41).
+    const key = bookOf(id, meta) || id.split('-').slice(0, 2).join('-');
     if (!buckets.has(key)) buckets.set(key, []);
     buckets.get(key)!.push(id);
   }

--- a/src/lib/store-ops.ts
+++ b/src/lib/store-ops.ts
@@ -13,6 +13,24 @@ import { grade as gradeCard, newCard, type Grade } from './srs';
 const DAY_MS = 86_400_000;
 
 /** End of the exam day — the ceiling every SRS interval is clamped under. */
+/**
+ * Whether a raw date-input value is safe to commit as an exam date.
+ *
+ * An empty or half-typed value parses to `NaN`, and a `NaN` exam time does not
+ * announce itself: `examTimeOf` returns it, `srs.grade` computes `daysLeft`
+ * from it, and `NaN > 0` is false — so the interval clamp, the one guarantee
+ * that every card is seen once more before the quiz, silently stops applying
+ * and cards begin scheduling past the exam never to return. Nothing on screen
+ * says so beyond a "NaN days until Invalid Date" in the header.
+ *
+ * This lives here rather than in a view because the quiz date is editable from
+ * two screens, and the first version of this guard was written in only one of
+ * them (#41).
+ */
+export function isUsableExamDate(raw: string): boolean {
+  return raw !== '' && Number.isFinite(new Date(`${raw}T23:59:59`).getTime());
+}
+
 export function examTimeOf(settings: Settings): number {
   return new Date(`${settings.examDate}T23:59:59`).getTime();
 }

--- a/src/views/Plan.tsx
+++ b/src/views/Plan.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { buildSchedule, currentWeek, PHASES } from '../data/plan';
+import { isUsableExamDate } from '../lib/store-ops';
 import { TOPIC_LABELS } from '../data/types';
 import { planStartOf } from '../lib/store-ops';
 import type { StoreApi } from '../lib/useStore';
@@ -43,7 +44,13 @@ export default function Plan({ api }: { api: StoreApi }) {
               className="ctl"
               type="date"
               value={store.settings.examDate}
-              onChange={(e) => updateSettings({ examDate: e.target.value })}
+              // Guarded exactly as the Settings copy of this field is: an
+              // emptied or half-typed date commits NaN, which silently disables
+              // the SRS exam clamp (#41).
+              onChange={(e) => {
+                const raw = e.target.value;
+                if (isUsableExamDate(raw)) updateSettings({ examDate: raw });
+              }}
             />
           </Field>
         </div>

--- a/src/views/Review.tsx
+++ b/src/views/Review.tsx
@@ -80,20 +80,35 @@ export default function Review({ api }: { api: StoreApi }) {
     Math.round(store.settings.newLimit * specFor(store.settings.difficulty).newLimitFactor),
   );
 
+  /**
+   * The three plates answer two different questions, so they are counted two
+   * different ways.
+   *
+   * `due` and `fresh` describe *this session*: what it is about to ask. They
+   * therefore follow the same rule the queue does — revision from anywhere,
+   * new material from the phase — because a plate that promises one number and
+   * then hands over a different one is worse than no plate.
+   *
+   * `seen` describes *your progress*, which is not a property of today's
+   * session at all. Counting it inside the phase would mean the work you did
+   * in Phase 1 disappeared from the screen the week Phase 2 began.
+   */
   const counts = useMemo(() => {
     const now = Date.now();
     const inScope = scopedIds ? new Set(scopedIds) : null;
-    let due = 0, fresh = 0, total = 0, bankActionable = 0;
+    let due = 0, fresh = 0, seen = 0, bankActionable = 0;
     for (const it of items) {
       const c = cards[it.id];
-      const actionable = isNew(c) || isDue(c, now);
-      if (actionable) bankActionable++;
+      if (isNew(c) || isDue(c, now)) bankActionable++;
+      if (!isNew(c)) {
+        seen++;
+        if (isDue(c, now)) due++;
+        continue;
+      }
       if (inScope && !inScope.has(it.id)) continue;
-      total++;
-      if (isNew(c)) fresh++;
-      else if (isDue(c, now)) due++;
+      fresh++;
     }
-    return { due, fresh, total, bankActionable };
+    return { due, fresh, seen, total: items.length, bankActionable };
   }, [cards, items, scopedIds]);
 
   function start(ignorePlan = false) {
@@ -114,10 +129,36 @@ export default function Review({ api }: { api: StoreApi }) {
      * pre-filter preserves order, so the new-card cut is untouched.
      */
     const actionable = (id: string) => isNew(cards[id]) || isDue(cards[id]);
+
+    /**
+     * The plan rations *new* material. It does not get to withhold a card that
+     * is already due.
+     *
+     * Scoping both together silently broke the one guarantee the scheduler
+     * makes. `grade()` clamps every interval so nothing is scheduled past the
+     * quiz date without one more look at it — but a due date is only a promise
+     * if something acts on it. Phases 2 through 4 do not list `book-order`
+     * among their topics, so scoping due cards by phase meant every card built
+     * during Phase 1 fell out of the queue for the five or six weeks those
+     * phases run, however overdue it got. The widening could not save it
+     * either: `withTopUp` fires only when the phase cannot fill a session, and
+     * a phase holding three thousand items always can.
+     *
+     * So the two are scoped separately. New cards come from the phase, which is
+     * what "follow the plan" means — you are not introduced to the Epistles in
+     * week two. Due cards come from wherever they are, which is what spaced
+     * repetition means.
+     */
+    const inScope = scopedIds ? new Set(scopedIds) : null;
+    const admits = (id: string) => {
+      const c = cards[id];
+      if (!isNew(c) && isDue(c)) return true;
+      return isNew(c) && (!inScope || inScope.has(id));
+    };
     const ids =
       ignorePlan || !scopedIds
         ? allIds
-        : withTopUp(scopedIds.filter(actionable), allIds.filter(actionable), sessionLimit);
+        : withTopUp(allIds.filter(admits), allIds.filter(actionable), sessionLimit);
 
     const build = (from: string[]) =>
       buildQueue(from, cards, {
@@ -200,7 +241,7 @@ export default function Review({ api }: { api: StoreApi }) {
             <span className="k">New today</span>
           </Card>
           <Card className="stat">
-            <span className="n"><CountUp value={counts.total - counts.fresh} /></span>
+            <span className="n"><CountUp value={counts.seen} /></span>
             <span className="k">Seen so far</span>
           </Card>
         </div>

--- a/src/views/Review.tsx
+++ b/src/views/Review.tsx
@@ -206,7 +206,14 @@ export default function Review({ api }: { api: StoreApi }) {
   }
 
   if (!started) {
-    const inPhase = counts.due + counts.fresh;
+    // What the session can actually deal, not what is theoretically available.
+    // `fresh` counts every unseen card in scope, but the queue will only
+    // introduce `newToday` of them — so a phase holding nothing but new cards
+    // with a new-card limit of 0 offered an enabled Start button that dealt an
+    // empty session and jumped straight to "Session complete — 0 answered"
+    // (#41). Settings clamps the limit above 0, but an imported store or one
+    // written by an older build does not have to.
+    const inPhase = counts.due + Math.min(counts.fresh, newToday);
     const canStart = inPhase > 0 || (phase !== null && counts.bankActionable > 0);
     const widening = phase !== null && inPhase === 0 && counts.bankActionable > 0;
     return (
@@ -250,7 +257,7 @@ export default function Review({ api }: { api: StoreApi }) {
             Start review session
           </button>
           {phase && (
-            <button className="btn" onClick={() => start(true)}>
+            <button className="btn" onClick={() => start(true)} disabled={counts.bankActionable === 0}>
               {copy.settings.followPlan.studyEverything}
             </button>
           )}

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -17,6 +17,7 @@ import { useState } from 'react';
 import { DIFFICULTIES, type Difficulty } from '../data/types';
 import { useThemeMode, type ThemeMode } from '../lib/theme';
 import type { StoreApi } from '../lib/useStore';
+import { isUsableExamDate } from '../lib/store-ops';
 import { copy } from '../copy';
 import { Card, Field, Segmented, space, sx } from '../ui';
 
@@ -86,10 +87,6 @@ function limitToCommit(raw: string, bounds: { min: number; max: number }): numbe
  * cards start scheduling past the exam date never to return. Nothing on screen
  * says so beyond a "NaN days until Invalid Date" in the header (#40).
  */
-function isUsableExamDate(raw: string): boolean {
-  return raw !== '' && Number.isFinite(new Date(`${raw}T23:59:59`).getTime());
-}
-
 export default function Settings({ api }: { api: StoreApi }) {
   const { store, updateSettings } = api;
   const [themeMode, setTheme] = useThemeMode();

--- a/tests/e2e/plan.spec.ts
+++ b/tests/e2e/plan.spec.ts
@@ -40,15 +40,76 @@ test.describe('following the study plan', () => {
     ...over,
   });
 
-  test('the review session only asks what the current phase covers', async ({ page }) => {
+  test('a session mixes due cards from anywhere with new cards from the phase', async ({ page }) => {
+    // The whole rule in one session. All three seeded cards are due and they
+    // sit in three different phases, so all three are asked — a due date is a
+    // promise the queue has to keep. What the phase controls is the material
+    // you have never seen, and `newLimit: 0` here holds that at zero so the
+    // count is unambiguous.
     await openAs(page, { store: { cards: straddling, settings: settings({ followPlan: true }) } }, 'review');
 
     await expect(page.getByText(/Following the study plan/)).toBeVisible();
     await page.getByRole('button', { name: 'Start review session' }).click();
 
-    // One card, and it is the book-order one — not the numbers or events cards.
-    await expect(page.getByRole('progressbar', { name: '0 of 1 answered' })).toBeVisible();
+    await expect(page.getByRole('progressbar', { name: '0 of 3 answered' })).toBeVisible();
+  });
+
+  /**
+   * The plan rations new material; it does not withhold a card that is due.
+   *
+   * This is the regression that made the guarantee in `grade()` a lie. Every
+   * interval is clamped so nothing is scheduled past the quiz date without one
+   * more look — but a due date only means something if the queue acts on it.
+   * Phases 2 through 4 do not list `book-order` among their topics, so scoping
+   * due cards by phase dropped every card built during Phase 1 for the five or
+   * six weeks those phases run. The widening could not rescue it either:
+   * `withTopUp` fires only when a phase cannot fill a session, and Phase 2
+   * holds 3,434 items.
+   */
+  test('a card that is due is asked even when its topic is outside the phase', async ({ page }) => {
+    await openAs(page, {
+      store: {
+        // ITEM.mcq is `book-order`. Phase 2 — the OT sweep — does not cover it.
+        cards: { [ITEM.mcq]: dueCard(ITEM.mcq) },
+        settings: {
+          examDate: daysFromNow(60),
+          newLimit: 0,
+          sessionLimit: 60,
+          followPlan: true,
+          planStart: daysAgo(28),
+        },
+      },
+    }, 'review');
+
+    // Confirm the fixture really does put us past Phase 1, or the test proves
+    // nothing at all.
+    await expect(page.getByText(/Following the study plan/)).toBeVisible();
+    await expect(page.getByText(/Following the study plan: Phase 1/)).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Start review session' }).click();
     await expect(page.getByText('Which book immediately follows Genesis?')).toBeVisible();
+  });
+
+  test('new material still comes only from the current phase', async ({ page }) => {
+    // The other half of the same rule: due cards are admitted from anywhere,
+    // but the plan still decides what you meet for the first time.
+    await openAs(page, {
+      store: {
+        cards: {},
+        settings: {
+          examDate: daysFromNow(60),
+          newLimit: 8,
+          sessionLimit: 8,
+          followPlan: true,
+          planStart: daysFromNow(0),
+        },
+      },
+    }, 'review');
+
+    await page.getByRole('button', { name: 'Start review session' }).click();
+    // Phase 1 covers book-order and summaries only.
+    const kicker = page.locator('.kicker, .pill').first();
+    await expect(kicker).toHaveText(/Book Order|Book Summaries/);
   });
 
   test('you can set the plan aside for one session without changing the setting', async ({ page }) => {

--- a/tests/e2e/queue.spec.ts
+++ b/tests/e2e/queue.spec.ts
@@ -10,7 +10,8 @@
  * says so directly rather than as a puzzling UI failure.
  */
 import { expect, test } from '@playwright/test';
-import { buildQueue, type CardState } from '../../src/lib/srs';
+import { allItems, ITEMS_BY_ID } from '../../src/lib/generate';
+import { buildQueue, type CardState, type ItemMeta } from '../../src/lib/srs';
 
 const DAY = 86_400_000;
 
@@ -65,6 +66,50 @@ test.describe('review queue', () => {
 
     expect(q).toHaveLength(5);
     expect([...q].sort()).toEqual(['card-0', 'card-1', 'card-2', 'card-3', 'card-4']);
+  });
+
+  /**
+   * The same rule, against the shape the real bank actually has (#41).
+   *
+   * The synthetic deck above cannot catch the bug this guards: its ids are
+   * `card-0`, `card-1`… and the spreading step keys on the first two
+   * id segments, so every card became its own bucket and round-robin trivially
+   * preserved the urgency order. The real bank is the opposite shape — 6,098
+   * items across a few dozen id families like `gen-position` and `det-ev`,
+   * each spanning the whole canon — so the round-robin gave a family holding
+   * two due cards the same share as one holding nine hundred. Because the
+   * session cut ran *after* that, the spreading step was silently deciding
+   * which cards survived it, and the most overdue routinely lost.
+   */
+  test('a real backlog still yields the most overdue cards, spread across books', () => {
+    const items = allItems();
+    const meta: Record<string, ItemMeta> = {};
+    for (const i of items) meta[i.id] = { tier: i.tier, book: i.book };
+
+    // 3,000 cards in rotation, overdue by amounts that do not follow bank order.
+    const now = Date.now();
+    const cards: Record<string, CardState> = {};
+    items.slice(0, 3000).forEach((it, n) => {
+      cards[it.id] = {
+        id: it.id, ease: 2.5, interval: 1, reps: 3, lapses: 0,
+        due: now - ((n * 7919) % 600) * DAY, lastSeen: now - DAY, recent: [2, 2],
+      };
+    });
+
+    const limit = 60;
+    const q = buildQueue(items.map((i) => i.id), cards, {
+      newLimit: 0, sessionLimit: limit, difficulty: 'medium', meta, seed: 'fixed',
+    }, now);
+
+    const mostOverdue = new Set(
+      Object.values(cards).sort((a, b) => a.due - b.due).slice(0, limit).map((c) => c.id),
+    );
+    expect(q).toHaveLength(limit);
+    expect(q.filter((id) => mostOverdue.has(id))).toHaveLength(limit);
+
+    // And still spread: taking the most urgent must not mean taking one book.
+    const books = new Set(q.map((id) => ITEMS_BY_ID.get(id)!.book ?? '-'));
+    expect(books.size).toBeGreaterThan(5);
   });
 
   test('new cards are still capped by the new-card limit', () => {

--- a/tests/e2e/review.spec.ts
+++ b/tests/e2e/review.spec.ts
@@ -27,7 +27,7 @@ test.describe('daily review', () => {
     [ITEM.order]: dueCard(ITEM.order, { due: Date.now() + 7 * DAY }),
   };
 
-  test('the idle screen counts inside the phase the plan is asking for', async ({ page }) => {
+  test('the idle screen counts what the session will actually ask', async ({ page }) => {
     await openAs(page, {
       store: {
         cards: straddlingPlan,
@@ -35,10 +35,15 @@ test.describe('daily review', () => {
       },
     }, 'review');
 
-    // Only the book-order card is in Phase 1, so it is the only one counted.
-    await expectStat(page, 'Due now', 1);
+    // Two of the three are due and both sit outside Phase 1 — but the plan
+    // rations new material, not revision, so the session will ask them and the
+    // plate has to say so. Counting due cards by phase would promise one and
+    // then hand over two.
+    await expectStat(page, 'Due now', 2);
     await expectStat(page, 'New today', 5); // capped by the new-card limit
-    await expectStat(page, 'Seen so far', 1);
+    // Progress, not session: all three have been seen, and the third stays
+    // counted even though its topic is outside the current phase.
+    await expectStat(page, 'Seen so far', 3);
   });
 
   test('turning the plan off counts what is due, what is new, and what has been seen', async ({ page }) => {


### PR DESCRIPTION
**A regression from #40, currently live.** Worth merging ahead of anything else.

## What broke

`grade()` clamps every interval so nothing is scheduled past the quiz date
without one more look at it. That is the single promise the scheduler makes, and
the README leads with it.

#40 made the study plan filter the daily queue — and scoped **the whole queue**
by phase, due cards included. Phases 2, 3 and 4 do not list `book-order` among
their topics. So every book-order card built during Phase 1 fell out of the
queue for the five or six weeks those phases run, no matter how overdue it got.
A due date was being set and then ignored.

The widening could not rescue it. `withTopUp` fires only when the phase cannot
fill a session, and Phase 2's scope is **3,434 items** against a session limit
of 60 — so it never fired once.

Concretely: spend Phase 1 learning the 66 books, move into the OT sweep, and the
app stops asking you about book order entirely until Phase 5. Which is exactly
the material Phase 1 exists to build, and exactly what spaced repetition is for.

## The fix

Scope the two things separately, because they answer to different rules:

- **New cards** come from the current phase. That is what following a plan
  means — you are not introduced to the Epistles in week two.
- **Due cards** come from wherever they are. That is what spaced repetition
  means.

## The plates follow the same split

`Due now` and `New today` describe *this session*, so they are now counted the
way the queue actually selects. A plate that promises one number and then hands
over a different one is worse than no plate.

`Seen so far` describes *progress*, which is not a property of today's session
at all — it is now counted across the whole bank. Previously it was scoped to
the phase, so the work you did in Phase 1 disappeared from the screen the week
Phase 2 began.

## Tests

**152 passing, up from 150.** Two new regression tests:

- a due card is asked even when its topic is outside the phase — seeded past
  Phase 1, and it asserts the fixture really is past Phase 1 first, so the test
  cannot silently stop proving anything
- new material still comes only from the current phase — the other half of the
  rule, so the fix cannot over-correct into ignoring the plan

Two existing tests were asserting the buggy behaviour and now assert the
corrected rule. `npm run check` and `npm run validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
