### PR TITLE
Move the default quiz date to January 2027

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,10 +202,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - **The default quiz date moved to 31 January 2027** (was 31 October 2026).
-  This is the date a fresh install starts with; an existing install keeps
-  whatever date is already saved in its Settings, so members who set up
-  before this change move the date forward themselves under Settings or
-  Plan. The exact January date is still to be confirmed and may change again.
+  A fresh install starts with the new date. An existing account whose saved
+  date is still the old default, never changed by hand, is moved to the new
+  one on load, so its Dashboard countdown and Study Plan follow the new
+  timeline without a visit to Settings. A date the member chose deliberately
+  is left alone. The exact January date is still to be confirmed and may
+  change again.
 
 - **Accessibility** ([#40]). The app had no `<h1>` and never moved focus when
   you changed tabs, so a screen-reader user activating Quiz heard nothing and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **The default quiz date moved to 31 January 2027** (was 31 October 2026).
+  This is the date a fresh install starts with; an existing install keeps
+  whatever date is already saved in its Settings, so members who set up
+  before this change move the date forward themselves under Settings or
+  Plan. The exact January date is still to be confirmed and may change again.
+
 - **Accessibility** ([#40]). The app had no `<h1>` and never moved focus when
   you changed tabs, so a screen-reader user activating Quiz heard nothing and
   was left in the navigation. Ordering questions signalled a correctly placed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Scripture Mastery
 
-A whole-Bible survey trainer built for one job: walking into a quiz at the end of
-October knowing the content of all 66 books.
+A whole-Bible survey trainer built for one job: walking into the quiz, currently
+set for the end of January 2027, knowing the content of all 66 books.
 
 **6,581 questions** generated from structured data: 66 books with a full outline
 and episode list each, 595 dated events, 360 per-book figures, 233 people, 54
@@ -85,7 +85,7 @@ const daysLeft = Math.max(0, Math.ceil((examDate - now) / DAY));
 if (daysLeft > 0) interval = Math.min(interval, Math.max(1, Math.floor(daysLeft / 2)));
 ```
 
-Every card gets at least one more look before the test. As October 31 approaches,
+Every card gets at least one more look before the test. As the quiz date approaches,
 intervals compress automatically and the whole deck converges into daily review.
 Change the date in **Progress → Settings** and the schedule re-plans itself.
 

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -36,7 +36,7 @@ export const copy = {
     /** e.g. "1,240 questions across 66 books" */
     tagline: (questionCount: number) =>
       `${questionCount.toLocaleString()} questions across 66 books`,
-    /** e.g. "112 days until October 4" — the meaningful, actionable figure */
+    /** e.g. "112 days until January 31" — the meaningful, actionable figure */
     countdown: (daysLeft: number, examDateLabel: string) =>
       `${daysLeft.toLocaleString()} day${daysLeft === 1 ? '' : 's'} until ${examDateLabel}`,
     signOut: 'Sign out',

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -63,7 +63,7 @@ export interface Store {
 }
 
 export const DEFAULT_SETTINGS: Settings = {
-  examDate: '2026-10-31',
+  examDate: '2027-01-31',
   newLimit: 20,
   sessionLimit: 60,
   difficulty: 'medium',

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -62,6 +62,15 @@ export interface Store {
   starred: string[];
 }
 
+/**
+ * The default quiz date before it moved to January 2027. A store saved under
+ * the old default and never touched still carries this exact string, and
+ * `mergeSettings` rewrites it, so an account set up before the move follows
+ * the new timeline without anyone editing the date by hand. A date the member
+ * chose deliberately is a different string and is left alone.
+ */
+export const LEGACY_DEFAULT_EXAM = '2026-10-31';
+
 export const DEFAULT_SETTINGS: Settings = {
   examDate: '2027-01-31',
   newLimit: 20,
@@ -72,6 +81,20 @@ export const DEFAULT_SETTINGS: Settings = {
   // wrong for everybody the moment it was written; `planStartOf` resolves it.
   planStart: '',
 };
+
+/**
+ * Saved settings laid over the defaults, the one merge every load path uses
+ * (Firestore snapshot, import, the E2E hook). A document written before a
+ * setting existed has no value for it and every reader downstream trusts
+ * Settings to be complete, so the gaps are filled here; and a quiz date that
+ * is still the pre-January default is moved to the current one, because that
+ * value was never a choice, only the absence of one.
+ */
+export function mergeSettings(saved: Partial<Settings> | undefined): Settings {
+  const merged: Settings = { ...DEFAULT_SETTINGS, ...(saved ?? {}) };
+  if (merged.examDate === LEGACY_DEFAULT_EXAM) merged.examDate = DEFAULT_SETTINGS.examDate;
+  return merged;
+}
 
 export function emptyStore(): Store {
   return { cards: {}, settings: { ...DEFAULT_SETTINGS }, log: [], starred: [] };
@@ -95,7 +118,7 @@ export function importStore(json: string): Store | null {
     if (typeof parsed !== 'object' || parsed === null) return null;
     return {
       cards: parsed.cards ?? {},
-      settings: { ...DEFAULT_SETTINGS, ...(parsed.settings ?? {}) },
+      settings: mergeSettings(parsed.settings),
       log: parsed.log ?? [],
       starred: parsed.starred ?? [],
     };

--- a/src/lib/useStore.e2e.ts
+++ b/src/lib/useStore.e2e.ts
@@ -14,7 +14,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { User } from 'firebase/auth';
 import { isAllowedEmail } from './firebase.e2e';
-import { emptyStore, type Settings, type Store } from './storage';
+import { emptyStore, mergeSettings, type Settings, type Store } from './storage';
 import type { CardState, Grade } from './srs';
 import { E2E_AUTH_EVENT, E2E_AUTH_KEY, E2E_STORE_KEY } from './e2e-keys';
 import {
@@ -36,14 +36,14 @@ function readStore(): Store {
   if (!raw) return emptyStore();
   try {
     const parsed = JSON.parse(raw) as Partial<Store>;
-    // Settings are spread over the defaults rather than taken whole: a seeded
+    // Settings go through the same merge as a Firestore snapshot: a seeded
     // fixture writes only the keys its test cares about, so anything added
-    // since (difficulty in #36, followPlan in #40) has to back-fill here just
-    // as it does off a Firestore snapshot.
+    // since (difficulty in #36, followPlan in #40) back-fills here too, and
+    // so does the move off the old default quiz date.
     const base = emptyStore();
     return {
       cards: parsed.cards ?? base.cards,
-      settings: { ...base.settings, ...(parsed.settings ?? {}) },
+      settings: mergeSettings(parsed.settings),
       log: parsed.log ?? base.log,
       starred: parsed.starred ?? base.starred,
     };

--- a/src/lib/useStore.ts
+++ b/src/lib/useStore.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { onAuthStateChanged, type User } from 'firebase/auth';
 import { doc, onSnapshot, setDoc } from 'firebase/firestore';
 import { auth, db, isAllowedEmail } from './firebase';
-import { DEFAULT_SETTINGS, emptyStore, type Settings, type Store } from './storage';
+import { emptyStore, mergeSettings, type Settings, type Store } from './storage';
 import type { CardState, Grade } from './srs';
 import {
   applyAnswer,
@@ -44,13 +44,9 @@ export function useStore() {
       ref,
       (snap) => {
         const saved = snap.exists() ? (snap.data() as Store) : emptyStore();
-        // A document written before a setting existed simply has no value for
-        // it, and every reader downstream trusts Settings to be complete. Fill
-        // the gaps from the defaults on the way in, the way importStore and the
-        // E2E hook already do, so #36's difficulty control and #40's
-        // follow-the-plan switch have something to show an account that
-        // predates them.
-        const data: Store = { ...saved, settings: { ...DEFAULT_SETTINGS, ...saved.settings } };
+        // Defaults under the saved settings, and the pre-January quiz date
+        // moved forward, in the one place that logic lives (see mergeSettings).
+        const data: Store = { ...saved, settings: mergeSettings(saved.settings) };
         storeRef.current = data;
         setStore(data);
         setStoreReady(true);

--- a/tests/e2e/progress.spec.ts
+++ b/tests/e2e/progress.spec.ts
@@ -19,6 +19,22 @@ test.describe('progress and settings', () => {
     await expect(page.locator('#sl')).toHaveValue('120');
   });
 
+  test('a store still on the old October default is moved to the January date on load', async ({ page }) => {
+    await openAs(page, { store: { settings: { examDate: '2026-10-31', newLimit: 20, sessionLimit: 60 } } }, 'settings');
+
+    await expect(page.locator('#exam2')).toHaveValue('2027-01-31');
+    // The rewrite happens on read, like the other back-fills, so the saved
+    // document carries the new date from the next write on.
+    await page.locator('#nl').fill('25');
+    expect((await readStore(page)).settings).toMatchObject({ examDate: '2027-01-31', newLimit: 25 });
+  });
+
+  test('a quiz date the member chose is left alone on load', async ({ page }) => {
+    await openAs(page, { store: { settings: { examDate: '2026-11-14', newLimit: 20, sessionLimit: 60 } } }, 'settings');
+
+    await expect(page.locator('#exam2')).toHaveValue('2026-11-14');
+  });
+
   test('the quiz date drives the countdown in the header', async ({ page }) => {
     await openAs(page, {}, 'settings');
 


### PR DESCRIPTION
Moves the default quiz date from 31 October 2026 to January 2027.

## What changes

- `src/lib/storage.ts`: `DEFAULT_SETTINGS.examDate`. This is the date a fresh install starts with.
- `CHANGELOG.md`: a Changed entry.

## Two things to know

1. **The exact January date is not settled yet.** The 31st is a placeholder so the plan and countdown land in the right month; adjust once it is known.
2. **Existing installs are moved forward, but only when they never chose a date.** `examDate` is saved per member and the stored value wins over the default. `mergeSettings`, the one merge every load path uses (Firestore snapshot, import, and the E2E hook), rewrites a stored `2026-10-31`, the old default exactly, to the new date on read; the next write persists it, the same way the difficulty and follow-plan back-fills already work. Any other value was a choice and is left alone. Two browser tests cover both cases. If you would rather not touch stored settings at all, drop the second and third commits and the PR is the one-line default change.

`npm run check` and `npm run build` pass.

