### PR TITLE
Stop three Which-book cards from naming their own answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Three "Which book is this?" cards named their own answer.** Hosea's and
+  Haggai's one-line summaries and Malachi's distinctive fact each carried the
+  book's name inside the quoted line, so the card was a label rather than a
+  question. The three lines now say "the prophet" or "this book" instead,
+  and `npm run validate` gains a hard check that fails whenever a quoting
+  book prompt (summary, key verse or distinctive fact) contains the bare
+  title of its answer. "Which book immediately follows 1 Samuel?" is not a
+  quoting prompt and is left alone.
+
 - **Missing the last card of a review session graded it three times** ([#40]).
   A missed card is requeued to the end of the session; when it *was* the end,
   the next card had the same id, the card component was never remounted, and

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -47,6 +47,23 @@ hard('mcq items with duplicate distractors', items.filter((i) => i.distractors &
   hard(`mcq items with duplicate ${level} distractors`, withSet.filter((i) => dupes(optionsOf(i)).length > 0), (i: Item) => i.id);
 });
 
+// A "Which book is this?" card hands over its answer when the quoted line names
+// the book — "God tells Hosea to marry…" is not a question about Hosea, it is a
+// label. Only the quoting shapes are checked (the summary, the key verse, the
+// distinctive fact); "Which book immediately follows 1 Samuel?" names a book on
+// purpose. The bare title is compared (Kings, not 1 Kings), so a line naming
+// one of a numbered pair leaks half the answer and is still caught.
+const QUOTING_BOOK_PROMPT = /^Which book is this(?: from| true of)?\? "(.*)"$/;
+const bareTitle = (name: string) => name.replace(/^[123] /, '');
+hard(
+  'book prompts whose quoted line names the answer',
+  items.filter((i) => {
+    const quoted = QUOTING_BOOK_PROMPT.exec(i.prompt)?.[1];
+    return quoted !== undefined && new RegExp(`\\b${bareTitle(i.answer)}\\b`, 'i').test(quoted);
+  }),
+  (i: Item) => `${i.id} | ${i.prompt}`,
+);
+
 hard('order items with a duplicated step', items.filter((i) => i.kind === 'order' && i.sequence && dupes(i.sequence).length > 0), (i: Item) => i.id);
 hard('order items with fewer than 3 steps', items.filter((i) => i.kind === 'order' && (i.sequence?.length ?? 0) < 3), (i: Item) => i.id);
 hard('items pointing at a book that does not exist', items.filter((i) => i.book && !BOOKS.some((b) => b.id === i.book)), (i: Item) => `${i.id} -> ${i.book}`);

--- a/src/data/books.ts
+++ b/src/data/books.ts
@@ -511,7 +511,7 @@ export const BOOKS: Book[] = [
   {
     id: 'hosea', name: 'Hosea', abbr: 'Hos', order: 28, testament: 'OT', division: 'Minor Prophets',
     author: 'Hosea', chapters: 14, era: 'c. 750–715 BC',
-    oneLine: 'God tells Hosea to marry an unfaithful wife as a living picture of Israel’s spiritual adultery.',
+    oneLine: 'God tells the prophet to marry an unfaithful wife as a living picture of Israel’s spiritual adultery.',
     theme: 'Covenant love that pursues the unfaithful.',
     keyPeople: ['Hosea', 'Gomer', 'Jezreel', 'Lo-ruhamah', 'Lo-ammi'],
     keyEvents: ['Marriage to Gomer', 'Children with symbolic names', 'Buying Gomer back', 'Call to return to the LORD'],
@@ -645,7 +645,7 @@ export const BOOKS: Book[] = [
   {
     id: 'haggai', name: 'Haggai', abbr: 'Hag', order: 37, testament: 'OT', division: 'Minor Prophets',
     author: 'Haggai', chapters: 2, era: '520 BC',
-    oneLine: 'Haggai shames the returned exiles into finishing the temple they abandoned for their own houses.',
+    oneLine: 'A prophet shames the returned exiles into finishing the temple they abandoned for their own houses.',
     theme: 'Priorities — "Consider your ways."',
     keyPeople: ['Haggai', 'Zerubbabel', 'Joshua the high priest', 'Darius'],
     keyEvents: ['Rebuke for paneled houses while the temple lies in ruins', 'Work on the temple resumes', 'Promise of greater glory'],

--- a/src/data/details/minor-prophets.ts
+++ b/src/data/details/minor-prophets.ts
@@ -436,6 +436,6 @@ export const MINOR_PROPHET_DETAILS: BookDetail[] = [
       { ref: 'Malachi 3:6', text: 'For I the LORD do not change; therefore you, O children of Jacob, are not consumed.' },
       { ref: 'Malachi 3:10', text: 'Bring the full tithe into the storehouse… and thereby put me to the test, says the LORD of hosts.' },
     ],
-    distinctive: 'The Old Testament’s last word in the Hebrew ordering is different, but in the Christian canon Malachi ends it — pointing straight at John the Baptist.',
+    distinctive: 'The Old Testament’s last word in the Hebrew ordering is different, but in the Christian canon this book ends it, pointing straight at John the Baptist.',
   },
 ];


### PR DESCRIPTION
Three "Which book is this?" cards gave the answer away in the quoted line:

| Card | Line |
|---|---|
| Hosea, summary | "God tells **Hosea** to marry an unfaithful wife..." |
| Haggai, summary | "**Haggai** shames the returned exiles..." |
| Malachi, distinctive | "...in the Christian canon **Malachi** ends it..." |

## What changes

- The three data lines now say "the prophet" or "this book". Same text shows in the Library card and detail panel, where the book name is already the heading.
- `scripts/validate.ts` gains a hard check: any prompt of the shape `Which book is this? "..."`, `Which book is this from? "..."`, or `Which book is this true of? "..."` fails when the quoted line contains the bare title of its answer (Kings, not 1 Kings, so a line naming half of a numbered pair is still caught). "Which book immediately follows 1 Samuel?" names a book on purpose and is not a quoting prompt, so it is not checked. The check runs in CI via the existing `npm run validate` step.
- A Fixed entry in the changelog.

Only the seventeen prophetic books generate these cards, so the gate found exactly these three. `npm run validate`, `npm run check` and `npm run build` pass.
