### PR TITLE
Drop the eighteen book-order cards answered by their own prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
+- **Eighteen book-order cards answered by the name in their own prompt.**
+  "Which book immediately precedes 2 Samuel?" and "Which book immediately
+  follows 1 Samuel?" test reading, not the canon, and the same goes for
+  every numbered pair (Kings, Chronicles, Corinthians, Thessalonians,
+  Timothy, Peter) and the run of 1, 2 and 3 John. The generator now skips a
+  follows/precedes card whenever the answer is the numbered sibling of the
+  book asked; the outer edges of each pair ("precedes 1 Samuel", "follows
+  2 Samuel") stay. `npm run validate` gains a hard check so they cannot come
+  back. Bank drops from 6,098 to 6,080.
+
 - **"Christ in Scripture" is no longer a study category** ([#16]). The topic is
   gone from the `Topic` union, the topic labels, both study-plan phases that
   listed it, and the 66 "How does X point to Christ?" questions it generated.

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -13,7 +13,7 @@ import { LISTS } from '../src/data/extras';
 import { ESSENTIAL_ITEM_IDS } from '../src/lib/generate-essentials';
 import { TOPIC_LABELS } from '../src/data/types';
 import type { Difficulty, Item } from '../src/data/types';
-import { allItems } from '../src/lib/generate';
+import { allItems, sameTitle } from '../src/lib/generate';
 
 const items = allItems();
 const problems: string[] = [];
@@ -62,6 +62,15 @@ hard(
     return quoted !== undefined && new RegExp(`\\b${bareTitle(i.answer)}\\b`, 'i').test(quoted);
   }),
   (i: Item) => `${i.id} | ${i.prompt}`,
+);
+
+// A book-order card is a reading test, not a canon test, when the answer is
+// the numbered sequel or prequel of the book in the prompt: "Which book
+// precedes 2 Samuel?" The generator skips those; this keeps them skipped.
+hard(
+  'book-order prompts answered by the numbered sibling of the book asked',
+  items.filter((i) => i.topic === 'book-order' && /^Which book immediately (follows|precedes) (.+)\?$/.test(i.prompt) && sameTitle(i.prompt.replace(/^Which book immediately (follows|precedes) /, '').replace(/\?$/, ''), i.answer)),
+  (i: Item) => `${i.id} | ${i.prompt} -> ${i.answer}`,
 );
 
 hard('order items with a duplicated step', items.filter((i) => i.kind === 'order' && i.sequence && dupes(i.sequence).length > 0), (i: Item) => i.id);

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -233,10 +233,13 @@ function buildBookItems(): Item[] {
       });
     }
 
-    // --- Position in canon
+    // --- Position in canon. A numbered sequel is skipped in both directions:
+    // "Which book follows 1 Samuel?" and "Which book precedes 2 Samuel?" are
+    // answered by the name in the prompt, so they test reading, not the canon.
+    // The pair's outer edges ("precedes 1 Samuel", "follows 2 Samuel") stay.
     const nextAnswer = b.order < 66 ? BOOKS[b.order].name : 'Nothing — it is the last book of the Bible';
     const nextSets = bookOrderSets(b, nextAnswer, `next-${b.id}`);
-    items.push({
+    if (!sameTitle(b.name, nextAnswer)) items.push({
       id: `gen-position-${b.id}`, kind: 'mcq', topic: 'book-order', tier: 3, book: b.id,
       prompt: `Which book immediately follows ${b.name}?`,
       answer: nextAnswer,
@@ -248,7 +251,7 @@ function buildBookItems(): Item[] {
         : { distractors: ['Jude', '3 John', '2 Peter'], distractorsBy: nextSets.distractorsBy }),
     });
 
-    if (b.order > 1) {
+    if (b.order > 1 && !sameTitle(b.name, BOOKS[b.order - 2].name)) {
       items.push({
         id: `gen-prev-${b.id}`, kind: 'mcq', topic: 'book-order', tier: 3, book: b.id,
         prompt: `Which book immediately precedes ${b.name}?`,
@@ -697,6 +700,12 @@ function slug(s: string): string {
 let cache: Item[] | null = null;
 
 /** The full item bank. Stable ids mean SRS progress survives content edits. */
+/** Whether two book names differ only by their number: 1 Samuel and 2 Samuel, 2 John and 3 John. */
+export function sameTitle(a: string, b: string): boolean {
+  const bare = (n: string) => n.replace(/^[123] /, '');
+  return a !== b && bare(a) === bare(b);
+}
+
 export function allItems(): Item[] {
   if (cache) return cache;
   const items = [


### PR DESCRIPTION
"Which book immediately precedes 2 Samuel?" is answered by reading the prompt. The same holds for every numbered pair (Samuel, Kings, Chronicles, Corinthians, Thessalonians, Timothy, Peter) and the run of 1, 2 and 3 John: eighteen cards in all.

## What changes

- `generate.ts` skips a follows/precedes card whenever the answer is the numbered sibling of the book asked (`sameTitle`). The outer edges of each pair stay: "precedes 1 Samuel" (Ruth) and "follows 2 Samuel" (1 Kings) are real questions.
- `validate.ts` gains a hard check so the class cannot come back.
- A Removed entry in the changelog. Bank drops from 6,098 to 6,080; every book still clears the 20-question floor.

The eighteen dropped ids are exactly `gen-position-1-*` for the first of each pair, `gen-prev-2-*` for the second, plus `gen-position-2-john` and `gen-prev-3-john`. Any saved progress on those ids is simply never dealt again, the same as with the earlier bank reductions.

`npm run check`, `npm run validate`, `npm run build` and the full Playwright suite (150 pass) are green.

## Merge order

Rebased onto main after #44 and #45 landed. These six PRs are a stack, so each merges cleanly if taken in this order:

**1. #48 Drop the eighteen book-order cards answered by their own prompt (this PR)**
2. #49 Explain every book-order card after it is answered
3. #50 Fold chapter content into Phase 1 of the study plan
4. #51 Stop the Study Plan page assuming an October quiz
5. #46 Replace every em-dash with plain punctuation
6. #47 Add a prose check to CI (em-dashes and filler phrases)

This one goes first; it is based directly on main.
