### PR TITLE
Stop the Study Plan page assuming an October quiz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The Study Plan page no longer assumes an October quiz.** The advice
+  card said you would "arrive in October"; it now says "arrive on quiz day",
+  since the date is a setting and the schedule above it is built from
+  whatever date is set.
+
 - **Three "Which book is this?" cards named their own answer.** Hosea's and
   Haggai's one-line summaries and Malachi's distinctive fact each carried the
   book's name inside the quoted line, so the card was a label rather than a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Book-order cards now explain themselves.** Missing "Which book immediately
+  precedes Daniel?" used to show the answer and nothing else. The feedback now
+  says where the book sits (book 27 of 66, the 5th of the 5 Major Prophets,
+  with the run listed), what stands either side of it, why that shelf is in
+  the order it is, and a mnemonic for the run. The shelf notes live in a new
+  `src/data/divisions.ts`, one entry per division, and the sentence is built
+  by `orderExplain` in `lib/generate.ts`. Because the text names the answer,
+  the pre-answer hint stays off for these cards, as it already does for any
+  card whose explanation would give the answer away.
+
 - **Difficulty became a real setting, and the study plan started driving what
   you study** ([#40]).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Phase 1 of the study plan now includes chapter content.** Following the
+  plan restricted the daily review to book order and summaries, 330 cards,
+  so a 60-card session was nearly all "which book follows". Key chapters
+  (what happens in 2 Samuel 7, where a given episode is found) are part of
+  the frame too, and the part that takes the whole phase to learn, so the
+  phase asks for them from day one. Phases 2 and 3 still sweep chapters
+  testament by testament.
+
 - **The default quiz date moved to 31 January 2027** (was 31 October 2026).
   A fresh install starts with the new date. An existing account whose saved
   date is still the old default, never changed by hand, is moved to the new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
+- **Eighteen book-order cards answered by the name in their own prompt.**
+  "Which book immediately precedes 2 Samuel?" and "Which book immediately
+  follows 1 Samuel?" test reading, not the canon, and the same goes for
+  every numbered pair (Kings, Chronicles, Corinthians, Thessalonians,
+  Timothy, Peter) and the run of 1, 2 and 3 John. The generator now skips a
+  follows/precedes card whenever the answer is the numbered sibling of the
+  book asked; the outer edges of each pair ("precedes 1 Samuel", "follows
+  2 Samuel") stay. `npm run validate` gains a hard check so they cannot come
+  back. Bank drops from 6,098 to 6,080.
+
 - **"Christ in Scripture" is no longer a study category** ([#16]). The topic is
   gone from the `Topic` union, the topic labels, both study-plan phases that
   listed it, and the 66 "How does X point to Christ?" questions it generated.

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -13,7 +13,7 @@ import { LISTS } from '../src/data/extras';
 import { ESSENTIAL_ITEM_IDS } from '../src/lib/generate-essentials';
 import { TOPIC_LABELS } from '../src/data/types';
 import type { Difficulty, Item } from '../src/data/types';
-import { allItems } from '../src/lib/generate';
+import { allItems, sameTitle } from '../src/lib/generate';
 
 const items = allItems();
 const problems: string[] = [];
@@ -62,6 +62,15 @@ hard(
     return quoted !== undefined && new RegExp(`\\b${bareTitle(i.answer)}\\b`, 'i').test(quoted);
   }),
   (i: Item) => `${i.id} | ${i.prompt}`,
+);
+
+// A book-order card is a reading test, not a canon test, when the answer is
+// the numbered sequel or prequel of the book in the prompt: "Which book
+// precedes 2 Samuel?" The generator skips those; this keeps them skipped.
+hard(
+  'book-order prompts answered by the numbered sibling of the book asked',
+  items.filter((i) => i.topic === 'book-order' && /^Which book immediately (follows|precedes) (.+)\?$/.test(i.prompt) && sameTitle(i.prompt.replace(/^Which book immediately (follows|precedes) /, '').replace(/\?$/, ''), i.answer)),
+  (i: Item) => `${i.id} | ${i.prompt} -> ${i.answer}`,
 );
 
 hard('order items with a duplicated step', items.filter((i) => i.kind === 'order' && i.sequence && dupes(i.sequence).length > 0), (i: Item) => i.id);

--- a/src/data/divisions.ts
+++ b/src/data/divisions.ts
@@ -1,0 +1,63 @@
+import type { Division } from './types';
+
+/**
+ * How to hold each division of the canon in memory: why its books sit in the
+ * order they do, and a mnemonic for the run. Read by the book-order cards'
+ * explanations (see `orderExplain` in lib/generate.ts), so a missed "Which
+ * book precedes Daniel?" teaches the shelf the book sits on instead of just
+ * naming the neighbour.
+ *
+ * `why` is the reasoning behind the order, `mnemonic` the handle for it. Both
+ * are written to be read after answering, so they may name any book freely.
+ */
+export interface DivisionGuide {
+  why: string;
+  mnemonic: string;
+}
+
+export const DIVISION_GUIDES: Record<Division, DivisionGuide> = {
+  Law: {
+    why: 'The five books of Moses run as one story, from creation to the edge of Canaan: origins, the exit from Egypt, the priests’ handbook, the wilderness census years, and Moses’ farewell sermons.',
+    mnemonic: '"General Electric Lights Never Dim": Genesis, Exodus, Leviticus, Numbers, Deuteronomy.',
+  },
+  History: {
+    why: 'Twelve books in rough time order: conquest (Joshua), the settlement (Judges, with Ruth as a story from that time and David’s ancestry), the kingdom in two doubled sets (Samuel, Kings), the same span retold from the temple’s point of view (Chronicles), and the return from exile (Ezra, Nehemiah, Esther).',
+    mnemonic: 'One conquest, two settlement books, three doubled pairs, three books of return. Ruth is the hinge between the judges and the kings.',
+  },
+  Wisdom: {
+    why: 'Ordered by the lives behind them: Job’s setting is the oldest, Psalms belong to David, and the last three (Proverbs, Ecclesiastes, Song of Solomon) are all tied to Solomon.',
+    mnemonic: 'One for Job, one for David, three for Solomon.',
+  },
+  'Major Prophets': {
+    why: 'Roughly chronological. Isaiah spoke before the exile, Jeremiah through the fall of Jerusalem, and Lamentations rides behind him as his grief for the fallen city. Ezekiel and Daniel both prophesied from exile in Babylon.',
+    mnemonic: '"I Just Like Eating Donuts": Isaiah, Jeremiah, Lamentations, Ezekiel, Daniel.',
+  },
+  'Minor Prophets': {
+    why: 'Not chronological. The first nine are pre-exile, mixed in order, and the last three (Haggai, Zechariah, Malachi) spoke after the return from Babylon, which is why Malachi closes the Old Testament looking forward.',
+    mnemonic: 'Four runs of three: Hosea Joel Amos, Obadiah Jonah Micah, Nahum Habakkuk Zephaniah, Haggai Zechariah Malachi. The last run came home from exile.',
+  },
+  Gospels: {
+    why: 'Matthew comes first as the bridge from the Old Testament, opening with a genealogy from Abraham. Mark and Luke follow as the other two synoptics, and John, written last and shaped differently, closes the four.',
+    mnemonic: 'Three synoptics, then John. Matthew leads because it opens where the Old Testament left off.',
+  },
+  Acts: {
+    why: 'Luke’s sequel stands alone between the Gospels and the letters because it tells how the churches the letters address were founded.',
+    mnemonic: 'Gospels tell what Jesus did; Acts tells what the church did next; the letters tell the church what to do now.',
+  },
+  'Pauline Epistles': {
+    why: 'Letters to churches come first (Romans through 2 Thessalonians), roughly longest to shortest, then letters to individuals (1 and 2 Timothy, Titus, Philemon), also longest to shortest.',
+    mnemonic: 'Churches first, then people, each group long to short. The four in the middle are "Go Eat Pop Corn": Galatians, Ephesians, Philippians, Colossians.',
+  },
+  'General Epistles': {
+    why: 'Hebrews leads as the longest and the only anonymous one. Then the writers: James (Jesus’ brother), Peter, John, and Jude (another brother of Jesus) closes.',
+    mnemonic: 'Hebrews, then two brothers of Jesus bracketing two apostles: James, Peter, John, Jude.',
+  },
+  Apocalyptic: {
+    why: 'Revelation stands alone at the end. It is the canon’s closing vision, and the last book John wrote.',
+    mnemonic: 'The Bible opens with a garden and closes with a city. Revelation is the city.',
+  },
+};
+
+/** The canon’s shelf plan, for the whole-Bible view a position question can give. */
+export const CANON_SHAPE =
+  'Old Testament, 39 books: 5 Law, 12 History, 5 Wisdom, 5 Major Prophets, 12 Minor Prophets. New Testament, 27 books: 4 Gospels, Acts, 13 letters of Paul, 8 general letters, Revelation.';

--- a/src/data/plan.ts
+++ b/src/data/plan.ts
@@ -3,8 +3,8 @@ import { BOOKS } from './books';
 
 /**
  * A phased plan built backwards from the exam date. The ordering is deliberate:
- * the frame (order, summaries) comes first, because every later fact has to
- * hang on something. Detail without a frame does not stick.
+ * the frame (order, summaries, key chapters) comes first, because every later
+ * fact has to hang on something. Detail without a frame does not stick.
  */
 export interface Phase {
   id: string;
@@ -22,13 +22,18 @@ export const PHASES: Phase[] = [
   {
     id: 'frame',
     name: 'Phase 1 — Build the Frame',
-    goal: 'Know all 66 books cold: order and one-sentence summary. Nothing else sticks without this.',
+    goal: 'Know all 66 books cold: order, one-sentence summary, and what happens in their key chapters. Nothing else sticks without this.',
     weight: 3,
-    topics: ['book-order', 'summaries'],
+    // Chapters sit here as well as in the two sweeps. Order and summaries
+    // alone are 330 cards, so a daily review of 60 was nearly all "which
+    // book follows", and that is the part of the frame a member learns in a
+    // week; the key chapters are the part that takes the whole phase.
+    topics: ['book-order', 'summaries', 'chapters'],
     scope: 'all',
     drills: [
       'Recite the 66 books in order out loud, daily',
       'Match each book to its one-line summary',
+      'For each book, name its key chapters and what happens in them',
     ],
   },
   {

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -233,10 +233,13 @@ function buildBookItems(): Item[] {
       });
     }
 
-    // --- Position in canon
+    // --- Position in canon. A numbered sequel is skipped in both directions:
+    // "Which book follows 1 Samuel?" and "Which book precedes 2 Samuel?" are
+    // answered by the name in the prompt, so they test reading, not the canon.
+    // The pair's outer edges ("precedes 1 Samuel", "follows 2 Samuel") stay.
     const nextAnswer = b.order < 66 ? BOOKS[b.order].name : 'Nothing — it is the last book of the Bible';
     const nextSets = bookOrderSets(b, nextAnswer, `next-${b.id}`);
-    items.push({
+    if (!sameTitle(b.name, nextAnswer)) items.push({
       id: `gen-position-${b.id}`, kind: 'mcq', topic: 'book-order', tier: 3, book: b.id,
       prompt: `Which book immediately follows ${b.name}?`,
       answer: nextAnswer,
@@ -248,7 +251,7 @@ function buildBookItems(): Item[] {
         : { distractors: ['Jude', '3 John', '2 Peter'], distractorsBy: nextSets.distractorsBy }),
     });
 
-    if (b.order > 1) {
+    if (b.order > 1 && !sameTitle(b.name, BOOKS[b.order - 2].name)) {
       items.push({
         id: `gen-prev-${b.id}`, kind: 'mcq', topic: 'book-order', tier: 3, book: b.id,
         prompt: `Which book immediately precedes ${b.name}?`,
@@ -697,6 +700,12 @@ function slug(s: string): string {
 let cache: Item[] | null = null;
 
 /** The full item bank. Stable ids mean SRS progress survives content edits. */
+/** Whether two book names differ only by their number: 1 Samuel and 2 Samuel, 2 John and 3 John. */
+export function sameTitle(a: string, b: string): boolean {
+  const bare = (n: string) => n.replace(/^[123] /, '');
+  return a !== b && bare(a) === bare(b);
+}
+
 export function allItems(): Item[] {
   if (cache) return cache;
   const items = [

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -12,7 +12,8 @@ import type { Person, Place } from '../data/people';
 import { ERAS, EVENTS } from '../data/timeline';
 import type { Era } from '../data/timeline';
 import { AUTHORED, LIST_DECOYS, LISTS } from '../data/extras';
-import type { Book, Item } from '../data/types';
+import type { Book, Division, Item } from '../data/types';
+import { DIVISION_GUIDES } from '../data/divisions';
 import { distractorSets, scopedSets } from './distractors';
 import { buildDetailItems } from './generate-detail';
 import { buildEssentialItems } from './generate-essentials';
@@ -152,6 +153,53 @@ function placePools(pl: Place, extract: (x: Place) => string[]): (() => string[]
  *    after the fact: the 124 cards that never had the bug keep their exact
  *    options, and only the six that did are corrected.
  */
+/** "1st", "2nd", "3rd", "4th", "11th", "12th", "13th" ... */
+function ordinal(n: number): string {
+  const tens = n % 100;
+  if (tens >= 11 && tens <= 13) return `${n}th`;
+  return `${n}${['th', 'st', 'nd', 'rd'][n % 10] ?? 'th'}`;
+}
+
+/** The division as a shelf you can count books on. */
+const SHELF_LABEL: Record<Division, string> = {
+  Law: 'books of the Law',
+  History: 'History books',
+  Wisdom: 'Wisdom books',
+  'Major Prophets': 'Major Prophets',
+  'Minor Prophets': 'Minor Prophets',
+  Gospels: 'Gospels',
+  Acts: 'Acts',
+  'Pauline Epistles': 'letters of Paul',
+  'General Epistles': 'General Epistles',
+  Apocalyptic: 'Apocalyptic',
+};
+
+/**
+ * The explanation behind a book-order card: where the book sits on its shelf,
+ * what stands either side of it, why that shelf is in the order it is, and a
+ * mnemonic for the run. Read after answering, so it names books freely; the
+ * hint-before-answer logic in QuestionCard suppresses it on its own.
+ */
+export function orderExplain(b: Book): string {
+  const shelf = BOOKS.filter((x) => x.division === b.division);
+  const at = shelf.findIndex((x) => x.id === b.id) + 1;
+  const place = shelf.length === 1
+    ? `${b.name} is book ${b.order} of 66 and stands on a shelf of its own.`
+    : `${b.name} is book ${b.order} of 66, the ${ordinal(at)} of the ${shelf.length} ${SHELF_LABEL[b.division]} (${shelf.map((x) => x.name).join(', ')}).`;
+  const edge = (x: Book, side: 'before' | 'after') => {
+    if (x.division === b.division) return x.name;
+    const n = BOOKS.filter((y) => y.division === x.division).length;
+    if (n === 1) return `${x.name}, a shelf of its own`;
+    return `${x.name}, ${side === 'before' ? 'closing' : 'opening'} the ${SHELF_LABEL[x.division]}`;
+  };
+  const prev = BOOKS[b.order - 2];
+  const next = BOOKS[b.order];
+  const before = prev ? `Before it: ${edge(prev, 'before')}.` : 'Before it: nothing; it opens the Bible.';
+  const after = next ? `After it: ${edge(next, 'after')}.` : 'After it: nothing; it closes the Bible.';
+  const g = DIVISION_GUIDES[b.division];
+  return `${place} ${before} ${after} Why this order: ${g.why} Mnemonic: ${g.mnemonic}`;
+}
+
 function bookOrderSets(subject: Book, answer: string, seed: string): Pick<Item, 'distractors' | 'distractorsBy'> {
   const notSubject = (n: string) => n !== subject.name;
   const names = (books: Book[]) => books.map((b) => b.name).filter(notSubject);
@@ -243,6 +291,7 @@ function buildBookItems(): Item[] {
       id: `gen-position-${b.id}`, kind: 'mcq', topic: 'book-order', tier: 3, book: b.id,
       prompt: `Which book immediately follows ${b.name}?`,
       answer: nextAnswer,
+      explain: orderExplain(b),
       // Revelation's medium options are authored, not drawn — the answer there
       // is a sentence rather than a book, and the three near-misses at the end
       // of the canon are the whole question. Only the alternates are generated.
@@ -256,6 +305,7 @@ function buildBookItems(): Item[] {
         id: `gen-prev-${b.id}`, kind: 'mcq', topic: 'book-order', tier: 3, book: b.id,
         prompt: `Which book immediately precedes ${b.name}?`,
         answer: BOOKS[b.order - 2].name,
+        explain: orderExplain(b),
         ...bookOrderSets(b, BOOKS[b.order - 2].name, `prev-${b.id}`),
       });
     }

--- a/src/views/Plan.tsx
+++ b/src/views/Plan.tsx
@@ -141,7 +141,7 @@ export default function Plan({ api }: { api: StoreApi }) {
           </p>
           <p className="small">
             <strong>Review is the whole game.</strong> New material every day without revisiting old
-            material means you arrive in October knowing the last two weeks well and everything else
+            material means you arrive on quiz day knowing the last two weeks well and everything else
             vaguely. The scheduler handles this for you — just clear your due cards.
           </p>
           <p className="small" style={sx({ marginBottom: 0 })}>


### PR DESCRIPTION
The Study Plan schedule is built from the quiz date setting, so moving the date to January (#44) already stretches it: the five phases redistribute their weights across the longer run of weeks. One line on the page did not follow: the study-advice card told the member they would "arrive in October knowing the last two weeks well". It now says "arrive on quiz day".

No other user-facing text in `src/` names October or the 2026 date. `npm run check`, `npm run build` and the plan and shell e2e specs pass.

## Merge order

Rebased onto main after #44 and #45 landed. These six PRs are a stack, so each merges cleanly if taken in this order:

1. #48 Drop the eighteen book-order cards answered by their own prompt
2. #49 Explain every book-order card after it is answered
3. #50 Fold chapter content into Phase 1 of the study plan
**4. #51 Stop the Study Plan page assuming an October quiz (this PR)**
5. #46 Replace every em-dash with plain punctuation
6. #47 Add a prose check to CI (em-dashes and filler phrases)

This branch includes the commit(s) from #48, #49, #50; once those merge, only this PR's own commit remains in the diff.
